### PR TITLE
Type advantage

### DIFF
--- a/rec/generator/Abilities.txt
+++ b/rec/generator/Abilities.txt
@@ -70,7 +70,7 @@ Tinted Lens:
 	Desc: Powers up \"not very effective\" moves.
 	Int: PowerChangeEffect
 	GetMultiplier: 
-	return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? 2 : 1;
+	return TypeAdvantage.isNotVeryEffective(user, victim, b) ? 2 : 1;
 	###
 *
 Swarm:
@@ -526,14 +526,14 @@ Filter:
 	Desc: Powers down super-effective moves.
 	Int: OpponentPowerChangeEffect
 	GetOppMultiplier: 
-	return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+	return TypeAdvantage.isSuperEffective(user, victim, b) ? .75 : 1;
 	###
 *
 Prism Armor:
 	Desc: Reduces the power of supereffective attacks taken.
 	Int: OpponentPowerChangeEffect
 	GetOppMultiplier: 
-	return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+	return TypeAdvantage.isSuperEffective(user, victim, b) ? .75 : 1;
 	###
 	MoldBreakerBreaker: True
 *
@@ -790,7 +790,7 @@ Wonder Guard:
 	}
 	
 	// Super effective moves hit
-	if (TypeAdvantage.getAdvantage(p, opp, b) > 1) {
+	if (TypeAdvantage.isSuperEffective(p, opp, b)) {
 		return true;
 	}
 	
@@ -833,7 +833,7 @@ Solid Rock:
 	Desc: Reduces damage from supereffective attacks.
 	Int: OpponentPowerChangeEffect
 	GetOppMultiplier: 
-	return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? .75 : 1;
+	return TypeAdvantage.isSuperEffective(user, victim, b) ? .75 : 1;
 	###
 *
 White Smoke:

--- a/rec/generator/Abilities.txt
+++ b/rec/generator/Abilities.txt
@@ -70,7 +70,7 @@ Tinted Lens:
 	Desc: Powers up \"not very effective\" moves.
 	Int: PowerChangeEffect
 	GetMultiplier: 
-	return Type.getAdvantage(user, victim, b) < 1 ? 2 : 1;
+	return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? 2 : 1;
 	###
 *
 Swarm:
@@ -527,14 +527,14 @@ Filter:
 	Desc: Powers down super-effective moves.
 	Int: OpponentPowerChangeEffect
 	GetOppMultiplier: 
-	return Type.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+	return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
 	###
 *
 Prism Armor:
 	Desc: Reduces the power of supereffective attacks taken.
 	Int: OpponentPowerChangeEffect
 	GetOppMultiplier: 
-	return Type.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+	return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
 	###
 	MoldBreakerBreaker: True
 *
@@ -791,7 +791,7 @@ Wonder Guard:
 	}
 	
 	// Super effective moves hit
-	if (Type.getAdvantage(p, opp, b) > 1) {
+	if (TypeAdvantage.getAdvantage(p, opp, b) > 1) {
 		return true;
 	}
 	
@@ -834,7 +834,7 @@ Solid Rock:
 	Desc: Reduces damage from supereffective attacks.
 	Int: OpponentPowerChangeEffect
 	GetOppMultiplier: 
-	return Type.getAdvantage(user, victim, b) < 1 ? .75 : 1;
+	return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? .75 : 1;
 	###
 *
 White Smoke:
@@ -856,7 +856,7 @@ Anticipation:
 	ActivePokemon other = b.getOtherPokemon(enterer.isPlayer());
 	for (Move m : other.getMoves(b)) {
 		Attack attack = m.getAttack();
-		if (Type.getBasicAdvantage(attack.getActualType(), enterer, b) > 1 || attack.isMoveType(MoveType.ONE_HIT_KO)) {
+		if (TypeAdvantage.getBasicAdvantage(attack.getActualType(), enterer, b) > 1 || attack.isMoveType(MoveType.ONE_HIT_KO)) {
 			// TODO: Shouldn't this be for a random move?
 			Messages.add(new MessageUpdate(enterer.getName() + "'s " + this.getName() + " made it shudder!"));
 			break;

--- a/rec/generator/Abilities.txt
+++ b/rec/generator/Abilities.txt
@@ -856,7 +856,7 @@ Anticipation:
 	ActivePokemon other = b.getOtherPokemon(enterer.isPlayer());
 	for (Move m : other.getMoves(b)) {
 		Attack attack = m.getAttack();
-		if (TypeAdvantage.getBasicAdvantage(attack.getActualType(), enterer, b) > 1 || attack.isMoveType(MoveType.ONE_HIT_KO)) {
+		if (attack.getActualType().getAdvantage().isSuperEffective(enterer, b) || attack.isMoveType(MoveType.ONE_HIT_KO)) {
 			// TODO: Shouldn't this be for a random move?
 			Messages.add(new MessageUpdate(enterer.getName() + "'s " + this.getName() + " made it shudder!"));
 			break;

--- a/rec/generator/Abilities.txt
+++ b/rec/generator/Abilities.txt
@@ -512,8 +512,7 @@ Leaf Guard:
 *
 Scrappy:
 	Desc: Enables moves to hit Ghost-type foes.
-	Int: AdvantageChanger
-	AdvantageChange: (attacking == Type.NORMAL || attacking == Type.FIGHTING) && defending[i] == Type.GHOST
+	RemoveAdvantageType: Ghost attacking == Type.NORMAL || attacking == Type.FIGHTING
 *
 Swift Swim:
 	Desc: Boosts the Pok\u00e9mon's Speed in rain.

--- a/rec/generator/Items.txt
+++ b/rec/generator/Items.txt
@@ -560,7 +560,7 @@ Ring Target:
 	Desc: Moves that would otherwise have no effect will land on the Pok\u00e9mon that holds it.
 	Price: 200
 	Fling: 10
-	AdvantageChange: TypeAdvantage.getBasicAdvantage(attacking, defending[i]) == 0
+	AdvantageChange: attacking.getAdvantage().doesNotEffect(defending[i])
 *
 Rocky Helmet:
 	Int: HoldItem, PhysicalContactEffect

--- a/rec/generator/Items.txt
+++ b/rec/generator/Items.txt
@@ -560,7 +560,15 @@ Ring Target:
 	Desc: Moves that would otherwise have no effect will land on the Pok\u00e9mon that holds it.
 	Price: 200
 	Fling: 10
-	AdvantageChange: attacking.getAdvantage().doesNotEffect(defending[i])
+	AdvantageChange:
+	for (int i = 0; i < defending.length; i++) {
+		if (attacking.getAdvantage().doesNotEffect(defending[i])) {
+			defending[i] = Type.NO_TYPE;	
+		}
+	}
+	
+	return defending;
+	###
 *
 Rocky Helmet:
 	Int: HoldItem, PhysicalContactEffect

--- a/rec/generator/Items.txt
+++ b/rec/generator/Items.txt
@@ -243,7 +243,7 @@ Expert Belt:
 	Price: 200
 	Fling: 10
 	GetMultiplier:
-		return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? 1.2 : 1;
+		return TypeAdvantage.isSuperEffective(user, victim, b) ? 1.2 : 1;
 		###
 *
 Flame Orb:
@@ -711,7 +711,7 @@ Weakness Policy:
 	Price: 200
 	Fling: 30
 	OnTakeDamage:
-		if (TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+		if (TypeAdvantage.isSuperEffective(user, victim, b)) {
 			victim.getAttributes().modifyStage(victim, victim, 2, Stat.ATTACK, b, CastSource.HELD_ITEM);
 			victim.getAttributes().modifyStage(victim, victim, 2, Stat.SP_ATTACK, b, CastSource.HELD_ITEM);
 		}
@@ -2187,7 +2187,7 @@ Enigma Berry:
 	NGPow: 100
 	Int: Berry, TakeDamageEffect
 	OnTakeDamage:
-		if (!victim.fullHealth() && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+		if (!victim.fullHealth() && TypeAdvantage.isSuperEffective(user, victim, b)) {
 			Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " restored its health!"));
 			victim.healHealthFraction(.25);
 			Messages.add(new MessageUpdate().updatePokemon(b, victim));

--- a/rec/generator/Items.txt
+++ b/rec/generator/Items.txt
@@ -243,7 +243,7 @@ Expert Belt:
 	Price: 200
 	Fling: 10
 	GetMultiplier:
-		return Type.getAdvantage(user, victim, b) > 1 ? 1.2 : 1;
+		return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? 1.2 : 1;
 		###
 *
 Flame Orb:
@@ -560,7 +560,7 @@ Ring Target:
 	Desc: Moves that would otherwise have no effect will land on the Pok\u00e9mon that holds it.
 	Price: 200
 	Fling: 10
-	AdvantageChange: Type.getBasicAdvantage(attacking, defending[i]) == 0
+	AdvantageChange: TypeAdvantage.getBasicAdvantage(attacking, defending[i]) == 0
 *
 Rocky Helmet:
 	Int: HoldItem, PhysicalContactEffect
@@ -711,7 +711,7 @@ Weakness Policy:
 	Price: 200
 	Fling: 30
 	OnTakeDamage:
-		if (Type.getAdvantage(user, victim, b) > 1) {
+		if (TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 			victim.getAttributes().modifyStage(victim, victim, 2, Stat.ATTACK, b, CastSource.HELD_ITEM);
 			victim.getAttributes().modifyStage(victim, victim, 2, Stat.SP_ATTACK, b, CastSource.HELD_ITEM);
 		}
@@ -2187,7 +2187,7 @@ Enigma Berry:
 	NGPow: 100
 	Int: Berry, TakeDamageEffect
 	OnTakeDamage:
-		if (!victim.fullHealth() && Type.getAdvantage(user, victim, b) > 1) {
+		if (!victim.fullHealth() && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 			Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " restored its health!"));
 			victim.healHealthFraction(.25);
 			Messages.add(new MessageUpdate().updatePokemon(b, victim));

--- a/rec/generator/Items.txt
+++ b/rec/generator/Items.txt
@@ -555,20 +555,12 @@ Red Card:
 	###
 *
 Ring Target:
-	Int: HoldItem, AdvantageChanger
+	Int: HoldItem, NoAdvantageChanger
 	Cat: Misc
 	Desc: Moves that would otherwise have no effect will land on the Pok\u00e9mon that holds it.
 	Price: 200
 	Fling: 10
-	AdvantageChange:
-	for (int i = 0; i < defending.length; i++) {
-		if (attacking.getAdvantage().doesNotEffect(defending[i])) {
-			defending[i] = Type.NO_TYPE;	
-		}
-	}
-	
-	return defending;
-	###
+	NegateNoAdvantage: true
 *
 Rocky Helmet:
 	Int: HoldItem, PhysicalContactEffect

--- a/rec/generator/Moves.txt
+++ b/rec/generator/Moves.txt
@@ -4154,7 +4154,7 @@ Conversion 2:
 	private List<Type> getResistances(ActivePokemon victim, Type attacking, Battle b) {
 		List<Type> types = new ArrayList<>();
 		for (Type t : Type.values()) {
-			if (TypeAdvantage.getBasicAdvantage(attacking, t) < 1 && !victim.isType(b, t)) {
+			if (attacking.getAdvantage().isNotVeryEffective(t) && !victim.isType(b, t)) {
 				types.add(t);
 			}
 		}
@@ -6137,7 +6137,7 @@ Freeze-Dry:
 	double multiplier = 1;
 	for (int i = 0; i < 2; i++) {
 		if (defendingType[i] == Type.WATER) {
-			multiplier *= 2/TypeAdvantage.getBasicAdvantage(moveType, defendingType[i]);
+			multiplier *= 2/moveType.getAdvantage().getAdvantage(defendingType[i]);
 		}
 	}
 	
@@ -6155,7 +6155,7 @@ Flying Press:
 	Cat: Physical
 	Int: AdvantageMultiplierMove
 	MultiplyAdvantage:
-	return TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[0])*TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[1]);
+	return TypeAdvantage.FLYING.getAdvantage(defendingType);
 	###
 *
 Topsy-Turvy:

--- a/rec/generator/Moves.txt
+++ b/rec/generator/Moves.txt
@@ -4154,7 +4154,7 @@ Conversion 2:
 	private List<Type> getResistances(ActivePokemon victim, Type attacking, Battle b) {
 		List<Type> types = new ArrayList<>();
 		for (Type t : Type.values()) {
-			if (Type.getBasicAdvantage(attacking, t) < 1 && !victim.isType(b, t)) {
+			if (TypeAdvantage.getBasicAdvantage(attacking, t) < 1 && !victim.isType(b, t)) {
 				types.add(t);
 			}
 		}
@@ -6137,7 +6137,7 @@ Freeze-Dry:
 	double multiplier = 1;
 	for (int i = 0; i < 2; i++) {
 		if (defendingType[i] == Type.WATER) {
-			multiplier *= 2/Type.getBasicAdvantage(moveType, defendingType[i]);
+			multiplier *= 2/TypeAdvantage.getBasicAdvantage(moveType, defendingType[i]);
 		}
 	}
 	
@@ -6155,7 +6155,7 @@ Flying Press:
 	Cat: Physical
 	Int: AdvantageMultiplierMove
 	MultiplyAdvantage:
-	return Type.getBasicAdvantage(Type.FLYING, defendingType[0])*Type.getBasicAdvantage(Type.FLYING, defendingType[1]);
+	return TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[0])*TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[1]);
 	###
 *
 Topsy-Turvy:

--- a/rec/generator/Moves.txt
+++ b/rec/generator/Moves.txt
@@ -6132,17 +6132,7 @@ Freeze-Dry:
 	Cat: Special
 	Acc: 100
 	Pow: 70
-	Int: AdvantageMultiplierMove
-	MultiplyAdvantage:
-	double multiplier = 1;
-	for (int i = 0; i < 2; i++) {
-		if (defendingType[i] == Type.WATER) {
-			multiplier *= 2/moveType.getAdvantage().getAdvantage(defendingType[i]);
-		}
-	}
-	
-	return multiplier;
-	###
+	SuperEffectiveAdvantageType: Water
 	Status: Frozen
 	EffChance: 10
 *
@@ -6155,7 +6145,7 @@ Flying Press:
 	Cat: Physical
 	Int: AdvantageMultiplierMove
 	MultiplyAdvantage:
-	return TypeAdvantage.FLYING.getAdvantage(defendingType);
+	return TypeAdvantage.FLYING.getAdvantage(defendingTypes);
 	###
 *
 Topsy-Turvy:

--- a/rec/generator/PokemonEffects.txt
+++ b/rec/generator/PokemonEffects.txt
@@ -553,10 +553,10 @@ Trapped:
 	TrappingMessage: trapped.getName() + " cannot be recalled at this time!"
 *	
 Foresight:
-	ForesightEffect: Normal Fighting Ghost
+	ForesightEffect: Ghost attacking == Type.NORMAL || attacking == Type.FIGHTING
 *
 MiracleEye:
-	ForesightEffect: Psychic Psychic Dark
+	ForesightEffect: Dark attacking == Type.PSYCHIC
 *
 Torment:
 	FailAbility: Aroma Veil

--- a/rec/generator/TeamEffects.txt
+++ b/rec/generator/TeamEffects.txt
@@ -59,7 +59,7 @@ StealthRock:
 	}
 	
 	Messages.add(new MessageUpdate(enterer.getName() + " was hurt by stealth rock!"));
-	enterer.reduceHealthFraction(b, TypeAdvantage.getBasicAdvantage(Type.ROCK, enterer, b)/8.0);
+	enterer.reduceHealthFraction(b, Type.ROCK.getAdvantage().getAdvantage(enterer, b)/8.0);
 	###
 	CastMessage: "Floating rocks were scattered all around!"
 	RapidSpin: "The floating rocks spun away!"

--- a/rec/generator/TeamEffects.txt
+++ b/rec/generator/TeamEffects.txt
@@ -59,7 +59,7 @@ StealthRock:
 	}
 	
 	Messages.add(new MessageUpdate(enterer.getName() + " was hurt by stealth rock!"));
-	enterer.reduceHealthFraction(b, Type.getBasicAdvantage(Type.ROCK, enterer, b)/8.0);
+	enterer.reduceHealthFraction(b, TypeAdvantage.getBasicAdvantage(Type.ROCK, enterer, b)/8.0);
 	###
 	CastMessage: "Floating rocks were scattered all around!"
 	RapidSpin: "The floating rocks spun away!"

--- a/rec/generator/interfaces.txt
+++ b/rec/generator/interfaces.txt
@@ -494,7 +494,7 @@ OpponentPowerChangeEffect:
 ***
 AdvantageMultiplierMove:
 	Method:
-		Header: double multiplyAdvantage(Type moveType, Type[] defendingType)
+		Header: double multiplyAdvantage(Type attackingType, Type[] defendingTypes)
 		Invoke: Multiply
 		InvokeParameters: ActivePokemon attacking
 		Move: attacking

--- a/rec/generator/interfaces.txt
+++ b/rec/generator/interfaces.txt
@@ -394,11 +394,10 @@ ChangeAttackTypeEffect:
 		InvokeName: updateAttackType
 	*
 ***
-AdvantageChanger:
+NoAdvantageChanger:
 	Method:
-		Header: Type[] getAdvantageChange(Type attackingType, Type[] defendingType)
-		Invoke: Update
-		Update: defendingType
+		Header: boolean negateNoAdvantage(Type attackingType, Type defendingType)
+		Invoke: Check true
 		InvokeParameters: Battle b, ActivePokemon attacking, ActivePokemon defending
 		SetInvokees:
 		// TODO: I really hate it when the invokee list takes from the attacker and the defender -- need to rewrite all of this
@@ -408,7 +407,6 @@ AdvantageChanger:
 		invokees.add(defending.getHeldItem(b));
 		invokees.add(attacking.getAbility());
 		###
-		InvokeName: updateDefendingType
 	*
 ***
 ChangeMoveListEffect:

--- a/rec/generator/override.txt
+++ b/rec/generator/override.txt
@@ -1904,7 +1904,7 @@ Override:
 		AddMapField: NGType: {0}
 		AddInterface: OpponentPowerChangeEffect
 		AddMapField: GetOppMultiplier:
-		if (user.getAttackType() == Type.{00} && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+		if (user.getAttackType() == Type.{00} && TypeAdvantage.isSuperEffective(user, victim, b)) {
 			Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 			victim.consumeItem(b);
 			return .5;

--- a/rec/generator/override.txt
+++ b/rec/generator/override.txt
@@ -1971,12 +1971,23 @@ Override:
 	*
 ***
 Override:
+	RemoveAdvantageType:
+		AddInterface: AdvantageChanger
+		AddMapField: AdvantageChange: 
+		if ({2-}) {
+			TypeAdvantage.removeDefendingType(defending, Type.{11});
+		}
+		
+		return defending;
+		###
+	*
+***
+Override:
 	ForesightEffect:
 		AddMapField: CastMessage: user.getName() + " identified " + victim.getName() + "!"
 		AddMapField: CanHave: True
 		AddMapField: UsedProof: True
-		AddInterface: AdvantageChanger
-		AddMapField: AdvantageChange: (attacking == Type.{11} || attacking == Type.{22}) && defending[i] == Type.{33}
+		AddMapField: RemoveAdvantageType: {0}
 	*
 ***
 Override:
@@ -2187,15 +2198,6 @@ Override:
 AdvantageChanger:
 	AdvantageChange:
 		Header: Type[] getAdvantageChange(Type attacking, Type[] defending)
-		Body:
-		for (int i = 0; i < 2; i++) {
-			if ({0}) {
-				defending[i] = Type.NO_TYPE;	
-			}
-		}
-		
-		return defending;
-		###
 	*
 ***
 AdvantageMultiplierMove:

--- a/rec/generator/override.txt
+++ b/rec/generator/override.txt
@@ -2199,7 +2199,22 @@ NoAdvantageChanger:
 ***
 AdvantageMultiplierMove:
 	MultiplyAdvantage:
-		Header: double multiplyAdvantage(Type moveType, Type[] defendingType)
+		Header: double multiplyAdvantage(Type attackingType, Type[] defendingTypes)
+	*
+***
+Override:
+	SuperEffectiveAdvantageType:
+		AddInterface: AdvantageMultiplierMove
+		AddMapField: MultiplyAdvantage:
+		double multiplier = 1;
+		for (Type defendingType : defendingTypes) {
+			if (defendingType == Type.{00}) {
+				multiplier *= 2/attackingType.getAdvantage().getAdvantage(defendingType);
+			}
+		}
+		
+		return multiplier;
+		###
 	*
 ***
 Override:

--- a/rec/generator/override.txt
+++ b/rec/generator/override.txt
@@ -1904,7 +1904,7 @@ Override:
 		AddMapField: NGType: {0}
 		AddInterface: OpponentPowerChangeEffect
 		AddMapField: GetOppMultiplier:
-		if (user.getAttackType() == Type.{00} && Type.getAdvantage(user, victim, b) > 1) {
+		if (user.getAttackType() == Type.{00} && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 			Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 			victim.consumeItem(b);
 			return .5;

--- a/rec/generator/override.txt
+++ b/rec/generator/override.txt
@@ -1972,14 +1972,8 @@ Override:
 ***
 Override:
 	RemoveAdvantageType:
-		AddInterface: AdvantageChanger
-		AddMapField: AdvantageChange: 
-		if ({2-}) {
-			TypeAdvantage.removeDefendingType(defending, Type.{11});
-		}
-		
-		return defending;
-		###
+		AddInterface: NoAdvantageChanger
+		AddMapField: NegateNoAdvantage: defending == Type.{11} && ({2-})
 	*
 ***
 Override:
@@ -2195,9 +2189,12 @@ Override:
 		###
 	*
 ***
-AdvantageChanger:
-	AdvantageChange:
-		Header: Type[] getAdvantageChange(Type attacking, Type[] defending)
+NoAdvantageChanger:
+	NegateNoAdvantage:
+		Header: boolean negateNoAdvantage(Type attacking, Type defending)
+		Body:
+		return {0};
+		###
 	*
 ***
 AdvantageMultiplierMove:

--- a/src/battle/Battle.java
+++ b/src/battle/Battle.java
@@ -30,7 +30,7 @@ import battle.effect.generic.Weather;
 import item.ItemNamesies;
 import main.Game;
 import main.Global;
-import main.Type;
+import type.Type;
 import map.TerrainType;
 import message.MessageUpdate;
 import message.MessageUpdate.Update;

--- a/src/battle/Battle.java
+++ b/src/battle/Battle.java
@@ -581,7 +581,7 @@ public class Battle {
 		return damage;
 	}
 
-	private double getDamageModifier(ActivePokemon me, ActivePokemon o) {
+	protected double getDamageModifier(ActivePokemon me, ActivePokemon o) {
 		double modifier = 1;
 		modifier = PowerChangeEffect.updateModifier(modifier, this, me, o);
 		modifier = OpponentPowerChangeEffect.updateModifier(modifier, this, me, o);
@@ -651,7 +651,7 @@ public class Battle {
 	
 	// Returns true if the Pokemon is able to execute their turn by checking effects that have been casted upon them
 	// This is where BeforeTurnEffects are handled
-	private boolean ableToAttack(ActivePokemon p, ActivePokemon opp) {
+	protected boolean ableToAttack(ActivePokemon p, ActivePokemon opp) {
 		// Dead Pokemon can't attack and it's not nice to attack a deady
 		if (p.isFainted(this) || opp.isFainted(this)) {
 			return false;

--- a/src/battle/Battle.java
+++ b/src/battle/Battle.java
@@ -30,7 +30,6 @@ import battle.effect.generic.Weather;
 import item.ItemNamesies;
 import main.Game;
 import main.Global;
-import type.Type;
 import map.TerrainType;
 import message.MessageUpdate;
 import message.MessageUpdate.Update;
@@ -47,6 +46,7 @@ import trainer.Team;
 import trainer.Trainer;
 import trainer.Trainer.Action;
 import trainer.WildPokemon;
+import type.TypeAdvantage;
 import util.PokeString;
 import util.RandomUtils;
 
@@ -556,8 +556,8 @@ public class Battle {
 		int attackStat = Stat.getStat(attacking, me, o, this);
 		int defenseStat = Stat.getStat(defending, o, me, this);
 		
-		double stab = Type.getSTAB(this, me);
-		double adv = Type.getAdvantage(me, o, this);
+		double stab = TypeAdvantage.getSTAB(this, me);
+		double adv = TypeAdvantage.getAdvantage(me, o, this);
 		
 		int damage = (int)Math.ceil(((((2*level/5.0 + 2)*attackStat*power/defenseStat)/50.0) + 2)*stab*adv*random/100.0);
 		

--- a/src/battle/attack/Attack.java
+++ b/src/battle/attack/Attack.java
@@ -280,14 +280,14 @@ public abstract class Attack implements Serializable {
 	}
 	
 	private boolean zeroAdvantage(Battle b, ActivePokemon p, ActivePokemon opp) {
-		if (TypeAdvantage.getAdvantage(p, opp, b) > 0) {
-			return false;
+		if (TypeAdvantage.doesNotEffect(p, opp, b)) {
+			Messages.add(new MessageUpdate(TypeAdvantage.getDoesNotEffectMessage(opp)));
+			CrashDamageMove.invokeCrashDamageMove(b, p);
+
+			return true;
 		}
-		
-		Messages.add(new MessageUpdate("It doesn't affect " + opp.getName() + "!"));
-		CrashDamageMove.invokeCrashDamageMove(b, p);
-		
-		return true;
+
+		return false;
 	}
 	
 	// Takes type advantage, victim ability, and victim type into account to determine if the attack is effective
@@ -316,9 +316,11 @@ public abstract class Attack implements Serializable {
 	public void applyDamage(ActivePokemon me, ActivePokemon o, Battle b) {
 
 		// Print Advantage
-		double adv = TypeAdvantage.getAdvantage(me, o, b);
-		if (adv < 1) Messages.add(new MessageUpdate("It's not very effective..."));
-		else if (adv > 1) Messages.add(new MessageUpdate("It's super effective!"));
+		if (TypeAdvantage.isNotVeryEffective(me, o, b)) {
+			Messages.add(new MessageUpdate(TypeAdvantage.getNotVeryEffectiveMessage()));
+		} else if (TypeAdvantage.isSuperEffective(me, o, b)) {
+			Messages.add(new MessageUpdate(TypeAdvantage.getSuperEffectiveMessage()));
+		}
 		
 		// Deal damage
 		int damage = o.reduceHealth(b, b.calculateDamage(me, o));

--- a/src/battle/attack/Attack.java
+++ b/src/battle/attack/Attack.java
@@ -7060,7 +7060,7 @@ public abstract class Attack implements Serializable {
 		private List<Type> getResistances(ActivePokemon victim, Type attacking, Battle b) {
 			List<Type> types = new ArrayList<>();
 			for (Type t : Type.values()) {
-				if (TypeAdvantage.getBasicAdvantage(attacking, t) < 1 && !victim.isType(b, t)) {
+				if (attacking.getAdvantage().isNotVeryEffective(t) && !victim.isType(b, t)) {
 					types.add(t);
 				}
 			}
@@ -10399,7 +10399,7 @@ public abstract class Attack implements Serializable {
 			double multiplier = 1;
 			for (int i = 0; i < 2; i++) {
 				if (defendingType[i] == Type.WATER) {
-					multiplier *= 2/TypeAdvantage.getBasicAdvantage(moveType, defendingType[i]);
+					multiplier *= 2/moveType.getAdvantage().getAdvantage(defendingType[i]);
 				}
 			}
 			
@@ -10418,7 +10418,7 @@ public abstract class Attack implements Serializable {
 		}
 
 		public double multiplyAdvantage(Type moveType, Type[] defendingType) {
-			return TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[0])*TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[1]);
+			return TypeAdvantage.FLYING.getAdvantage(defendingType);
 		}
 	}
 

--- a/src/battle/attack/Attack.java
+++ b/src/battle/attack/Attack.java
@@ -59,6 +59,7 @@ import trainer.Team;
 import trainer.Trainer;
 import trainer.Trainer.Action;
 import trainer.WildPokemon;
+import type.TypeAdvantage;
 import util.GeneralUtils;
 import util.RandomUtils;
 
@@ -279,7 +280,7 @@ public abstract class Attack implements Serializable {
 	}
 	
 	private boolean zeroAdvantage(Battle b, ActivePokemon p, ActivePokemon opp) {
-		if (Type.getAdvantage(p, opp, b) > 0) {
+		if (TypeAdvantage.getAdvantage(p, opp, b) > 0) {
 			return false;
 		}
 		
@@ -315,7 +316,7 @@ public abstract class Attack implements Serializable {
 	public void applyDamage(ActivePokemon me, ActivePokemon o, Battle b) {
 
 		// Print Advantage
-		double adv = Type.getAdvantage(me, o, b);
+		double adv = TypeAdvantage.getAdvantage(me, o, b);
 		if (adv < 1) Messages.add(new MessageUpdate("It's not very effective..."));
 		else if (adv > 1) Messages.add(new MessageUpdate("It's super effective!"));
 		
@@ -404,7 +405,7 @@ public abstract class Attack implements Serializable {
 		return this.effectChance == 100 && this.category == MoveCategory.STATUS;
 	}
 	
-	public boolean canPrintCast() {
+	private boolean canPrintCast() {
 		return this.printCast;
 	}
 	

--- a/src/battle/attack/Attack.java
+++ b/src/battle/attack/Attack.java
@@ -360,7 +360,7 @@ public abstract class Attack implements Serializable {
 	}
 
 	// TODO: Need to make this final and have an overridable method that is called inside here
-	public 	void applyEffects(Battle b, ActivePokemon user, ActivePokemon victim) {
+	public void applyEffects(Battle b, ActivePokemon user, ActivePokemon victim) {
 		// Kill yourself!!
 		if (isMoveType(MoveType.USER_FAINTS)) {
 			user.killKillKillMurderMurderMurder(b);
@@ -7060,7 +7060,7 @@ public abstract class Attack implements Serializable {
 		private List<Type> getResistances(ActivePokemon victim, Type attacking, Battle b) {
 			List<Type> types = new ArrayList<>();
 			for (Type t : Type.values()) {
-				if (Type.getBasicAdvantage(attacking, t) < 1 && !victim.isType(b, t)) {
+				if (TypeAdvantage.getBasicAdvantage(attacking, t) < 1 && !victim.isType(b, t)) {
 					types.add(t);
 				}
 			}
@@ -10399,7 +10399,7 @@ public abstract class Attack implements Serializable {
 			double multiplier = 1;
 			for (int i = 0; i < 2; i++) {
 				if (defendingType[i] == Type.WATER) {
-					multiplier *= 2/Type.getBasicAdvantage(moveType, defendingType[i]);
+					multiplier *= 2/TypeAdvantage.getBasicAdvantage(moveType, defendingType[i]);
 				}
 			}
 			
@@ -10418,7 +10418,7 @@ public abstract class Attack implements Serializable {
 		}
 
 		public double multiplyAdvantage(Type moveType, Type[] defendingType) {
-			return Type.getBasicAdvantage(Type.FLYING, defendingType[0])*Type.getBasicAdvantage(Type.FLYING, defendingType[1]);
+			return TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[0])*TypeAdvantage.getBasicAdvantage(Type.FLYING, defendingType[1]);
 		}
 	}
 

--- a/src/battle/attack/Attack.java
+++ b/src/battle/attack/Attack.java
@@ -10395,11 +10395,11 @@ public abstract class Attack implements Serializable {
 			super.status = StatusCondition.FROZEN;
 		}
 
-		public double multiplyAdvantage(Type moveType, Type[] defendingType) {
+		public double multiplyAdvantage(Type attackingType, Type[] defendingTypes) {
 			double multiplier = 1;
-			for (int i = 0; i < 2; i++) {
-				if (defendingType[i] == Type.WATER) {
-					multiplier *= 2/moveType.getAdvantage().getAdvantage(defendingType[i]);
+			for (Type defendingType : defendingTypes) {
+				if (defendingType == Type.WATER) {
+					multiplier *= 2/attackingType.getAdvantage().getAdvantage(defendingType);
 				}
 			}
 			
@@ -10417,8 +10417,8 @@ public abstract class Attack implements Serializable {
 			super.moveTypes.add(MoveType.PHYSICAL_CONTACT);
 		}
 
-		public double multiplyAdvantage(Type moveType, Type[] defendingType) {
-			return TypeAdvantage.FLYING.getAdvantage(defendingType);
+		public double multiplyAdvantage(Type attackingType, Type[] defendingTypes) {
+			return TypeAdvantage.FLYING.getAdvantage(defendingTypes);
 		}
 	}
 

--- a/src/battle/attack/Attack.java
+++ b/src/battle/attack/Attack.java
@@ -45,7 +45,7 @@ import item.hold.SpecialTypeItem.GemItem;
 import item.hold.SpecialTypeItem.MemoryItem;
 import item.hold.SpecialTypeItem.PlateItem;
 import main.Global;
-import main.Type;
+import type.Type;
 import map.TerrainType;
 import message.MessageUpdate;
 import message.MessageUpdate.Update;

--- a/src/battle/attack/Move.java
+++ b/src/battle/attack/Move.java
@@ -6,7 +6,7 @@ import battle.effect.generic.EffectInterfaces.AttackSelectionEffect;
 import battle.effect.generic.EffectInterfaces.ChangeAttackTypeEffect;
 import battle.effect.generic.EffectInterfaces.ForceMoveEffect;
 import battle.effect.generic.EffectInterfaces.OpponentAttackSelectionEffect;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/battle/effect/DamageBlocker.java
+++ b/src/battle/effect/DamageBlocker.java
@@ -1,7 +1,7 @@
 package battle.effect;
 
 import battle.Battle;
-import main.Type;
+import type.Type;
 import pokemon.ActivePokemon;
 
 public interface DamageBlocker {

--- a/src/battle/effect/attack/ChangeTypeSource.java
+++ b/src/battle/effect/attack/ChangeTypeSource.java
@@ -1,7 +1,7 @@
 package battle.effect.attack;
 
 import battle.Battle;
-import main.Type;
+import type.Type;
 import pokemon.ActivePokemon;
 
 public interface ChangeTypeSource {

--- a/src/battle/effect/generic/BattleEffect.java
+++ b/src/battle/effect/generic/BattleEffect.java
@@ -12,7 +12,7 @@ import battle.effect.generic.EffectInterfaces.StageChangingEffect;
 import battle.effect.generic.EffectInterfaces.StatSwitchingEffect;
 import battle.effect.generic.EffectInterfaces.StatusPreventionEffect;
 import battle.effect.status.StatusCondition;
-import main.Type;
+import type.Type;
 import map.TerrainType;
 import message.MessageUpdate;
 import message.Messages;

--- a/src/battle/effect/generic/EffectInterfaces.java
+++ b/src/battle/effect/generic/EffectInterfaces.java
@@ -865,10 +865,10 @@ public final class EffectInterfaces {
 		}
 	}
 
-	public interface AdvantageChanger {
-		Type[] getAdvantageChange(Type attackingType, Type[] defendingType);
+	public interface NoAdvantageChanger {
+		boolean negateNoAdvantage(Type attackingType, Type defendingType);
 
-		static Type[] updateDefendingType(Battle b, ActivePokemon attacking, ActivePokemon defending, Type attackingType, Type[] defendingType) {
+		static boolean checkNoAdvantageChanger(Battle b, ActivePokemon attacking, ActivePokemon defending, Type attackingType, Type defendingType) {
 			// TODO: I really hate it when the invokee list takes from the attacker and the defender -- need to rewrite all of this
 			// Check the defending Pokemon's effects and held item as well as the attacking Pokemon's ability for advantage changes
 			List<Object> invokees = new ArrayList<>();
@@ -877,14 +877,16 @@ public final class EffectInterfaces {
 			invokees.add(attacking.getAbility());
 			
 			for (Object invokee : invokees) {
-				if (invokee instanceof AdvantageChanger && !Effect.isInactiveEffect(invokee, b)) {
+				if (invokee instanceof NoAdvantageChanger && !Effect.isInactiveEffect(invokee, b)) {
 					
-					AdvantageChanger effect = (AdvantageChanger)invokee;
-					defendingType = effect.getAdvantageChange(attackingType, defendingType);
+					NoAdvantageChanger effect = (NoAdvantageChanger)invokee;
+					if (effect.negateNoAdvantage(attackingType, defendingType)) {
+						return true;
+					}
 				}
 			}
 			
-			return defendingType;
+			return false;
 		}
 	}
 

--- a/src/battle/effect/generic/EffectInterfaces.java
+++ b/src/battle/effect/generic/EffectInterfaces.java
@@ -1063,15 +1063,15 @@ public final class EffectInterfaces {
 	}
 
 	public interface AdvantageMultiplierMove {
-		double multiplyAdvantage(Type moveType, Type[] defendingType);
+		double multiplyAdvantage(Type attackingType, Type[] defendingTypes);
 
-		static double updateModifier(double modifier, ActivePokemon attacking, Type moveType, Type[] defendingType) {
+		static double updateModifier(double modifier, ActivePokemon attacking, Type attackingType, Type[] defendingTypes) {
 			List<Object> invokees = Collections.singletonList(attacking.getAttack());
 			for (Object invokee : invokees) {
 				if (invokee instanceof AdvantageMultiplierMove && !Effect.isInactiveEffect(invokee, null)) {
 					
 					AdvantageMultiplierMove effect = (AdvantageMultiplierMove)invokee;
-					modifier *= effect.multiplyAdvantage(moveType, defendingType);
+					modifier *= effect.multiplyAdvantage(attackingType, defendingTypes);
 				}
 			}
 			

--- a/src/battle/effect/generic/EffectInterfaces.java
+++ b/src/battle/effect/generic/EffectInterfaces.java
@@ -5,7 +5,7 @@ import battle.attack.Attack;
 import battle.attack.Move;
 import battle.effect.status.StatusCondition;
 import main.Global;
-import main.Type;
+import type.Type;
 import map.TerrainType;
 import pokemon.ActivePokemon;
 import pokemon.Stat;

--- a/src/battle/effect/generic/PokemonEffect.java
+++ b/src/battle/effect/generic/PokemonEffect.java
@@ -13,7 +13,6 @@ import battle.effect.attack.ChangeTypeSource;
 import battle.effect.generic.BattleEffect.FieldUproar;
 import battle.effect.generic.EffectInterfaces.AbsorbDamageEffect;
 import battle.effect.generic.EffectInterfaces.AccuracyBypassEffect;
-import battle.effect.generic.EffectInterfaces.AdvantageChanger;
 import battle.effect.generic.EffectInterfaces.AlwaysCritEffect;
 import battle.effect.generic.EffectInterfaces.AttackSelectionEffect;
 import battle.effect.generic.EffectInterfaces.BeforeTurnEffect;
@@ -32,6 +31,7 @@ import battle.effect.generic.EffectInterfaces.ForceMoveEffect;
 import battle.effect.generic.EffectInterfaces.GroundedEffect;
 import battle.effect.generic.EffectInterfaces.HalfWeightEffect;
 import battle.effect.generic.EffectInterfaces.LevitationEffect;
+import battle.effect.generic.EffectInterfaces.NoAdvantageChanger;
 import battle.effect.generic.EffectInterfaces.OpponentAccuracyBypassEffect;
 import battle.effect.generic.EffectInterfaces.OpponentBeforeTurnEffect;
 import battle.effect.generic.EffectInterfaces.OpponentTrappingEffect;
@@ -53,7 +53,6 @@ import battle.effect.status.StatusCondition;
 import item.Item;
 import item.ItemNamesies;
 import main.Global;
-import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;
@@ -61,7 +60,7 @@ import pokemon.Gender;
 import pokemon.Stat;
 import pokemon.ability.Ability;
 import pokemon.ability.AbilityNamesies;
-import type.TypeAdvantage;
+import type.Type;
 import util.RandomUtils;
 
 import java.io.Serializable;
@@ -1621,7 +1620,7 @@ public abstract class PokemonEffect extends Effect implements Serializable {
 		}
 	}
 
-	static class Foresight extends PokemonEffect implements AdvantageChanger {
+	static class Foresight extends PokemonEffect implements NoAdvantageChanger {
 		private static final long serialVersionUID = 1L;
 
 		Foresight() {
@@ -1641,16 +1640,12 @@ public abstract class PokemonEffect extends Effect implements Serializable {
 			return user.getName() + " identified " + victim.getName() + "!";
 		}
 
-		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			if (attacking == Type.NORMAL || attacking == Type.FIGHTING) {
-				TypeAdvantage.removeDefendingType(defending, Type.GHOST);
-			}
-			
-			return defending;
+		public boolean negateNoAdvantage(Type attacking, Type defending) {
+			return defending == Type.GHOST && (attacking == Type.NORMAL || attacking == Type.FIGHTING);
 		}
 	}
 
-	static class MiracleEye extends PokemonEffect implements AdvantageChanger {
+	static class MiracleEye extends PokemonEffect implements NoAdvantageChanger {
 		private static final long serialVersionUID = 1L;
 
 		MiracleEye() {
@@ -1670,12 +1665,8 @@ public abstract class PokemonEffect extends Effect implements Serializable {
 			return user.getName() + " identified " + victim.getName() + "!";
 		}
 
-		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			if (attacking == Type.PSYCHIC) {
-				TypeAdvantage.removeDefendingType(defending, Type.DARK);
-			}
-			
-			return defending;
+		public boolean negateNoAdvantage(Type attacking, Type defending) {
+			return defending == Type.DARK && (attacking == Type.PSYCHIC);
 		}
 	}
 

--- a/src/battle/effect/generic/PokemonEffect.java
+++ b/src/battle/effect/generic/PokemonEffect.java
@@ -61,6 +61,7 @@ import pokemon.Gender;
 import pokemon.Stat;
 import pokemon.ability.Ability;
 import pokemon.ability.AbilityNamesies;
+import type.TypeAdvantage;
 import util.RandomUtils;
 
 import java.io.Serializable;
@@ -1627,16 +1628,6 @@ public abstract class PokemonEffect extends Effect implements Serializable {
 			super(EffectNamesies.FORESIGHT, -1, -1, false);
 		}
 
-		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			for (int i = 0; i < 2; i++) {
-				if ((attacking == Type.NORMAL || attacking == Type.FIGHTING) && defending[i] == Type.GHOST) {
-					defending[i] = Type.NO_TYPE;
-				}
-			}
-			
-			return defending;
-		}
-
 		public void cast(Battle b, ActivePokemon caster, ActivePokemon victim, CastSource source, boolean printCast) {
 			if (!victim.hasEffect(this.namesies)) {
 				super.cast(b, caster, victim, source, printCast);
@@ -1648,6 +1639,14 @@ public abstract class PokemonEffect extends Effect implements Serializable {
 
 		public String getCastMessage(Battle b, ActivePokemon user, ActivePokemon victim) {
 			return user.getName() + " identified " + victim.getName() + "!";
+		}
+
+		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
+			if (attacking == Type.NORMAL || attacking == Type.FIGHTING) {
+				TypeAdvantage.removeDefendingType(defending, Type.GHOST);
+			}
+			
+			return defending;
 		}
 	}
 
@@ -1658,16 +1657,6 @@ public abstract class PokemonEffect extends Effect implements Serializable {
 			super(EffectNamesies.MIRACLE_EYE, -1, -1, false);
 		}
 
-		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			for (int i = 0; i < 2; i++) {
-				if ((attacking == Type.PSYCHIC || attacking == Type.PSYCHIC) && defending[i] == Type.DARK) {
-					defending[i] = Type.NO_TYPE;
-				}
-			}
-			
-			return defending;
-		}
-
 		public void cast(Battle b, ActivePokemon caster, ActivePokemon victim, CastSource source, boolean printCast) {
 			if (!victim.hasEffect(this.namesies)) {
 				super.cast(b, caster, victim, source, printCast);
@@ -1679,6 +1668,14 @@ public abstract class PokemonEffect extends Effect implements Serializable {
 
 		public String getCastMessage(Battle b, ActivePokemon user, ActivePokemon victim) {
 			return user.getName() + " identified " + victim.getName() + "!";
+		}
+
+		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
+			if (attacking == Type.PSYCHIC) {
+				TypeAdvantage.removeDefendingType(defending, Type.DARK);
+			}
+			
+			return defending;
 		}
 	}
 

--- a/src/battle/effect/generic/PokemonEffect.java
+++ b/src/battle/effect/generic/PokemonEffect.java
@@ -53,7 +53,7 @@ import battle.effect.status.StatusCondition;
 import item.Item;
 import item.ItemNamesies;
 import main.Global;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/battle/effect/generic/TeamEffect.java
+++ b/src/battle/effect/generic/TeamEffect.java
@@ -283,7 +283,7 @@ public abstract class TeamEffect extends Effect implements Serializable {
 			}
 			
 			Messages.add(new MessageUpdate(enterer.getName() + " was hurt by stealth rock!"));
-			enterer.reduceHealthFraction(b, Type.getBasicAdvantage(Type.ROCK, enterer, b)/8.0);
+			enterer.reduceHealthFraction(b, TypeAdvantage.getBasicAdvantage(Type.ROCK, enterer, b)/8.0);
 		}
 
 		public void releaseRapidSpin(Battle b, ActivePokemon releaser) {

--- a/src/battle/effect/generic/TeamEffect.java
+++ b/src/battle/effect/generic/TeamEffect.java
@@ -14,14 +14,13 @@ import battle.effect.generic.EffectInterfaces.StatChangingEffect;
 import battle.effect.status.Status;
 import battle.effect.status.StatusCondition;
 import item.ItemNamesies;
-import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;
 import pokemon.Stat;
 import pokemon.ability.AbilityNamesies;
 import trainer.Trainer;
-import type.TypeAdvantage;
+import type.Type;
 
 import java.io.Serializable;
 
@@ -283,7 +282,7 @@ public abstract class TeamEffect extends Effect implements Serializable {
 			}
 			
 			Messages.add(new MessageUpdate(enterer.getName() + " was hurt by stealth rock!"));
-			enterer.reduceHealthFraction(b, TypeAdvantage.getBasicAdvantage(Type.ROCK, enterer, b)/8.0);
+			enterer.reduceHealthFraction(b, Type.ROCK.getAdvantage().getAdvantage(enterer, b)/8.0);
 		}
 
 		public void releaseRapidSpin(Battle b, ActivePokemon releaser) {

--- a/src/battle/effect/generic/TeamEffect.java
+++ b/src/battle/effect/generic/TeamEffect.java
@@ -14,7 +14,7 @@ import battle.effect.generic.EffectInterfaces.StatChangingEffect;
 import battle.effect.status.Status;
 import battle.effect.status.StatusCondition;
 import item.ItemNamesies;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/battle/effect/generic/TeamEffect.java
+++ b/src/battle/effect/generic/TeamEffect.java
@@ -21,6 +21,7 @@ import pokemon.ActivePokemon;
 import pokemon.Stat;
 import pokemon.ability.AbilityNamesies;
 import trainer.Trainer;
+import type.TypeAdvantage;
 
 import java.io.Serializable;
 

--- a/src/battle/effect/generic/Weather.java
+++ b/src/battle/effect/generic/Weather.java
@@ -9,7 +9,7 @@ import battle.effect.generic.EffectInterfaces.StatusPreventionEffect;
 import battle.effect.generic.EffectInterfaces.WeatherBlockerEffect;
 import battle.effect.status.StatusCondition;
 import item.Item;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/battle/effect/status/Burned.java
+++ b/src/battle/effect/status/Burned.java
@@ -3,7 +3,7 @@ package battle.effect.status;
 import battle.Battle;
 import battle.effect.generic.EffectInterfaces.EndTurnEffect;
 import battle.effect.generic.EffectInterfaces.StatChangingEffect;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/battle/effect/status/Frozen.java
+++ b/src/battle/effect/status/Frozen.java
@@ -5,7 +5,7 @@ import battle.attack.MoveType;
 import battle.effect.generic.CastSource;
 import battle.effect.generic.EffectInterfaces.BeforeTurnEffect;
 import battle.effect.generic.EffectInterfaces.TakeDamageEffect;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/battle/effect/status/Paralyzed.java
+++ b/src/battle/effect/status/Paralyzed.java
@@ -3,7 +3,7 @@ package battle.effect.status;
 import battle.Battle;
 import battle.effect.generic.EffectInterfaces.BeforeTurnEffect;
 import battle.effect.generic.EffectInterfaces.StatChangingEffect;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/battle/effect/status/Poisoned.java
+++ b/src/battle/effect/status/Poisoned.java
@@ -4,7 +4,7 @@ import battle.Battle;
 import battle.effect.generic.EffectInterfaces.EndTurnEffect;
 import battle.effect.generic.EffectNamesies;
 import battle.effect.generic.PokemonEffect;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/generator/PokeGen.java
+++ b/src/generator/PokeGen.java
@@ -12,7 +12,7 @@ import battle.effect.generic.Weather;
 import item.Item;
 import item.ItemNamesies;
 import main.Global;
-import main.Type;
+import type.Type;
 import pokemon.ability.Ability;
 import pokemon.ability.AbilityNamesies;
 import util.FileIO;

--- a/src/gui/view/NewPokemonView.java
+++ b/src/gui/view/NewPokemonView.java
@@ -8,7 +8,7 @@ import input.ControlKey;
 import input.InputControl;
 import main.Game;
 import main.Global;
-import main.Type;
+import type.Type;
 import pokemon.ActivePokemon;
 import pokemon.PokemonInfo;
 import trainer.CharacterData;

--- a/src/gui/view/PCView.java
+++ b/src/gui/view/PCView.java
@@ -11,7 +11,7 @@ import gui.panel.DrawPanel;
 import input.ControlKey;
 import input.InputControl;
 import main.Game;
-import main.Type;
+import type.Type;
 import map.Direction;
 import pokemon.ActivePokemon;
 import pokemon.PC;

--- a/src/gui/view/PartyView.java
+++ b/src/gui/view/PartyView.java
@@ -12,7 +12,7 @@ import input.ControlKey;
 import input.InputControl;
 import main.Game;
 import main.Global;
-import main.Type;
+import type.Type;
 import map.Direction;
 import pokemon.ActivePokemon;
 import pokemon.Stat;

--- a/src/gui/view/PokedexView.java
+++ b/src/gui/view/PokedexView.java
@@ -9,7 +9,7 @@ import gui.panel.DrawPanel;
 import input.ControlKey;
 import input.InputControl;
 import main.Game;
-import main.Type;
+import type.Type;
 import map.Direction;
 import pokemon.PC;
 import pokemon.PokemonInfo;

--- a/src/gui/view/bag/BagView.java
+++ b/src/gui/view/bag/BagView.java
@@ -21,7 +21,7 @@ import item.hold.HoldItem;
 import item.use.UseItem;
 import main.Game;
 import main.Global;
-import main.Type;
+import type.Type;
 import map.Direction;
 import message.MessageUpdate;
 import message.Messages;

--- a/src/gui/view/battle/PokemonAnimationState.java
+++ b/src/gui/view/battle/PokemonAnimationState.java
@@ -6,7 +6,7 @@ import gui.TileSet;
 import gui.panel.DrawPanel;
 import main.Game;
 import main.Global;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import pokemon.ActivePokemon;
 import pokemon.Gender;

--- a/src/gui/view/battle/handler/PokemonState.java
+++ b/src/gui/view/battle/handler/PokemonState.java
@@ -9,7 +9,7 @@ import gui.panel.DrawPanel;
 import gui.view.battle.BattleView;
 import gui.view.battle.VisualState;
 import main.Game;
-import main.Type;
+import type.Type;
 import map.Direction;
 import pokemon.ActivePokemon;
 import pokemon.Stat;

--- a/src/item/Item.java
+++ b/src/item/Item.java
@@ -12,7 +12,6 @@ import battle.effect.StallingEffect;
 import battle.effect.WeatherExtendingEffect;
 import battle.effect.generic.CastSource;
 import battle.effect.generic.Effect;
-import battle.effect.generic.EffectInterfaces.AdvantageChanger;
 import battle.effect.generic.EffectInterfaces.ApplyDamageEffect;
 import battle.effect.generic.EffectInterfaces.AttackSelectionEffect;
 import battle.effect.generic.EffectInterfaces.BeforeTurnEffect;
@@ -24,6 +23,7 @@ import battle.effect.generic.EffectInterfaces.EntryEffect;
 import battle.effect.generic.EffectInterfaces.GroundedEffect;
 import battle.effect.generic.EffectInterfaces.HalfWeightEffect;
 import battle.effect.generic.EffectInterfaces.LevitationEffect;
+import battle.effect.generic.EffectInterfaces.NoAdvantageChanger;
 import battle.effect.generic.EffectInterfaces.OpponentPowerChangeEffect;
 import battle.effect.generic.EffectInterfaces.PhysicalContactEffect;
 import battle.effect.generic.EffectInterfaces.PowerChangeEffect;
@@ -60,7 +60,6 @@ import item.use.PokemonUseItem;
 import item.use.TrainerUseItem;
 import item.use.UseItem;
 import main.Global;
-import type.Type;
 import map.TerrainType;
 import message.MessageUpdate;
 import message.Messages;
@@ -73,6 +72,7 @@ import pokemon.ability.AbilityNamesies;
 import pokemon.evolution.EvolutionMethod;
 import trainer.CharacterData;
 import trainer.Trainer;
+import type.Type;
 import type.TypeAdvantage;
 import util.RandomUtils;
 
@@ -1441,7 +1441,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 	}
 
-	static class RingTarget extends Item implements HoldItem, AdvantageChanger {
+	static class RingTarget extends Item implements HoldItem, NoAdvantageChanger {
 		private static final long serialVersionUID = 1L;
 
 		RingTarget() {
@@ -1453,14 +1453,8 @@ public abstract class Item implements Comparable<Item>, Serializable {
 			return 10;
 		}
 
-		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			for (int i = 0; i < defending.length; i++) {
-				if (attacking.getAdvantage().doesNotEffect(defending[i])) {
-					defending[i] = Type.NO_TYPE;
-				}
-			}
-			
-			return defending;
+		public boolean negateNoAdvantage(Type attacking, Type defending) {
+			return true;
 		}
 	}
 

--- a/src/item/Item.java
+++ b/src/item/Item.java
@@ -643,7 +643,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return Type.getAdvantage(user, victim, b) > 1 ? 1.2 : 1;
+			return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? 1.2 : 1;
 		}
 	}
 
@@ -1455,7 +1455,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 
 		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
 			for (int i = 0; i < 2; i++) {
-				if (Type.getBasicAdvantage(attacking, defending[i]) == 0) {
+				if (TypeAdvantage.getBasicAdvantage(attacking, defending[i]) == 0) {
 					defending[i] = Type.NO_TYPE;
 				}
 			}
@@ -1737,7 +1737,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public void takeDamage(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (Type.getAdvantage(user, victim, b) > 1) {
+			if (TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				victim.getAttributes().modifyStage(victim, victim, 2, Stat.ATTACK, b, CastSource.HELD_ITEM);
 				victim.getAttributes().modifyStage(victim, victim, 2, Stat.SP_ATTACK, b, CastSource.HELD_ITEM);
 			}
@@ -6763,7 +6763,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FIRE && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FIRE && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6794,7 +6794,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.WATER && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.WATER && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6825,7 +6825,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.ELECTRIC && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.ELECTRIC && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6856,7 +6856,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.GRASS && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.GRASS && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6887,7 +6887,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.ICE && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.ICE && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6918,7 +6918,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FIGHTING && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FIGHTING && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6949,7 +6949,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.POISON && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.POISON && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6980,7 +6980,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.GROUND && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.GROUND && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7011,7 +7011,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FLYING && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FLYING && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7042,7 +7042,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.PSYCHIC && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.PSYCHIC && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7073,7 +7073,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.BUG && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.BUG && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7104,7 +7104,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.ROCK && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.ROCK && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7135,7 +7135,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.GHOST && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.GHOST && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7166,7 +7166,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.DRAGON && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.DRAGON && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7197,7 +7197,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.DARK && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.DARK && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7228,7 +7228,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.STEEL && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.STEEL && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7259,7 +7259,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.NORMAL && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.NORMAL && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7290,7 +7290,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FAIRY && Type.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FAIRY && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7720,7 +7720,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public void takeDamage(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (!victim.fullHealth() && Type.getAdvantage(user, victim, b) > 1) {
+			if (!victim.fullHealth() && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " restored its health!"));
 				victim.healHealthFraction(.25);
 				Messages.add(new MessageUpdate().updatePokemon(b, victim));

--- a/src/item/Item.java
+++ b/src/item/Item.java
@@ -1454,7 +1454,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			for (int i = 0; i < 2; i++) {
+			for (int i = 0; i < defending.length; i++) {
 				if (attacking.getAdvantage().doesNotEffect(defending[i])) {
 					defending[i] = Type.NO_TYPE;
 				}

--- a/src/item/Item.java
+++ b/src/item/Item.java
@@ -643,7 +643,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? 1.2 : 1;
+			return TypeAdvantage.isSuperEffective(user, victim, b) ? 1.2 : 1;
 		}
 	}
 
@@ -1731,7 +1731,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public void takeDamage(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (TypeAdvantage.isSuperEffective(user, victim, b)) {
 				victim.getAttributes().modifyStage(victim, victim, 2, Stat.ATTACK, b, CastSource.HELD_ITEM);
 				victim.getAttributes().modifyStage(victim, victim, 2, Stat.SP_ATTACK, b, CastSource.HELD_ITEM);
 			}
@@ -6757,7 +6757,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FIRE && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FIRE && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6788,7 +6788,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.WATER && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.WATER && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6819,7 +6819,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.ELECTRIC && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.ELECTRIC && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6850,7 +6850,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.GRASS && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.GRASS && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6881,7 +6881,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.ICE && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.ICE && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6912,7 +6912,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FIGHTING && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FIGHTING && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6943,7 +6943,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.POISON && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.POISON && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -6974,7 +6974,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.GROUND && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.GROUND && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7005,7 +7005,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FLYING && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FLYING && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7036,7 +7036,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.PSYCHIC && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.PSYCHIC && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7067,7 +7067,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.BUG && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.BUG && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7098,7 +7098,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.ROCK && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.ROCK && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7129,7 +7129,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.GHOST && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.GHOST && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7160,7 +7160,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.DRAGON && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.DRAGON && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7191,7 +7191,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.DARK && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.DARK && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7222,7 +7222,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.STEEL && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.STEEL && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7253,7 +7253,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.NORMAL && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.NORMAL && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7284,7 +7284,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (user.getAttackType() == Type.FAIRY && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (user.getAttackType() == Type.FAIRY && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " decreased " + user.getName() + "'s attack!"));
 				victim.consumeItem(b);
 				return .5;
@@ -7714,7 +7714,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 		}
 
 		public void takeDamage(Battle b, ActivePokemon user, ActivePokemon victim) {
-			if (!victim.fullHealth() && TypeAdvantage.getAdvantage(user, victim, b) > 1) {
+			if (!victim.fullHealth() && TypeAdvantage.isSuperEffective(user, victim, b)) {
 				Messages.add(new MessageUpdate(victim.getName() + "'s " + this.name + " restored its health!"));
 				victim.healHealthFraction(.25);
 				Messages.add(new MessageUpdate().updatePokemon(b, victim));

--- a/src/item/Item.java
+++ b/src/item/Item.java
@@ -1455,7 +1455,7 @@ public abstract class Item implements Comparable<Item>, Serializable {
 
 		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
 			for (int i = 0; i < 2; i++) {
-				if (TypeAdvantage.getBasicAdvantage(attacking, defending[i]) == 0) {
+				if (attacking.getAdvantage().doesNotEffect(defending[i])) {
 					defending[i] = Type.NO_TYPE;
 				}
 			}

--- a/src/item/Item.java
+++ b/src/item/Item.java
@@ -73,6 +73,7 @@ import pokemon.ability.AbilityNamesies;
 import pokemon.evolution.EvolutionMethod;
 import trainer.CharacterData;
 import trainer.Trainer;
+import type.TypeAdvantage;
 import util.RandomUtils;
 
 import java.io.Serializable;

--- a/src/item/Item.java
+++ b/src/item/Item.java
@@ -60,7 +60,7 @@ import item.use.PokemonUseItem;
 import item.use.TrainerUseItem;
 import item.use.UseItem;
 import main.Global;
-import main.Type;
+import type.Type;
 import map.TerrainType;
 import message.MessageUpdate;
 import message.Messages;

--- a/src/item/berry/Berry.java
+++ b/src/item/berry/Berry.java
@@ -2,7 +2,7 @@ package item.berry;
 
 import item.hold.ConsumableItem;
 import item.hold.HoldItem;
-import main.Type;
+import type.Type;
 
 public interface Berry extends ConsumableItem, HoldItem {
 	Type naturalGiftType();

--- a/src/item/hold/SpecialTypeItem.java
+++ b/src/item/hold/SpecialTypeItem.java
@@ -1,7 +1,7 @@
 package item.hold;
 
 import battle.effect.generic.EffectInterfaces.PowerChangeEffect;
-import main.Type;
+import type.Type;
 
 public interface SpecialTypeItem extends HoldItem {
     Type getType();

--- a/src/main/TeamPlanner.java
+++ b/src/main/TeamPlanner.java
@@ -8,6 +8,7 @@ import pokemon.PokemonNamesies;
 import pokemon.Stat;
 import pokemon.ability.AbilityNamesies;
 import type.Type;
+import type.TypeAdvantage;
 import util.FileIO;
 import util.StringUtils;
 
@@ -304,8 +305,8 @@ public class TeamPlanner {
 						int first = firstType.getIndex();
 						int second = secondType.getIndex();
 						
-						double firstAdvantage = Type.getBasicAdvantage(attackType, firstType);
-						double secondAdvantage = Type.getBasicAdvantage(attackType, secondType);
+						double firstAdvantage = TypeAdvantage.getBasicAdvantage(attackType, firstType);
+						double secondAdvantage = TypeAdvantage.getBasicAdvantage(attackType, secondType);
 						
 						double advantage = firstAdvantage*secondAdvantage;
 						

--- a/src/main/TeamPlanner.java
+++ b/src/main/TeamPlanner.java
@@ -305,10 +305,7 @@ public class TeamPlanner {
 						int first = firstType.getIndex();
 						int second = secondType.getIndex();
 						
-						double firstAdvantage = TypeAdvantage.getBasicAdvantage(attackType, firstType);
-						double secondAdvantage = TypeAdvantage.getBasicAdvantage(attackType, secondType);
-						
-						double advantage = firstAdvantage*secondAdvantage;
+						double advantage = attackType.getAdvantage().getAdvantage(firstType, secondType);
 						
 						if (advantage > 1) {
 							coverageCount[first][second]++;

--- a/src/main/TeamPlanner.java
+++ b/src/main/TeamPlanner.java
@@ -7,6 +7,7 @@ import pokemon.PokemonInfo;
 import pokemon.PokemonNamesies;
 import pokemon.Stat;
 import pokemon.ability.AbilityNamesies;
+import type.Type;
 import util.FileIO;
 import util.StringUtils;
 

--- a/src/main/Type.java
+++ b/src/main/Type.java
@@ -16,25 +16,25 @@ import java.awt.image.BufferedImage;
 import java.io.Serializable;
 
 public enum Type implements Serializable {
-	NORMAL(0, "Normal", new Color(230, 230, 250), -1),
-	FIRE(1, "Fire", new Color(220, 20, 20), 8),
-	WATER(2, "Water", new Color(35, 120, 220), 9),
-	ELECTRIC(3, "Electric", new Color(255, 215, 0), 11),
-	GRASS(4, "Grass", new Color(120, 200, 80), 10),
-	ICE(5, "Ice", new Color(5, 235, 235), 13),
-	FIGHTING(6, "Fighting", new Color(165, 82, 57), 0),
-	POISON(7, "Poison", new Color(150, 30, 160), 2),
-	GROUND(8, "Ground", new Color(190, 170, 120), 3),
-	FLYING(9, "Flying", new Color(135, 206, 250), 1),
-	PSYCHIC(10, "Psychic", new Color(218, 112, 214), 12),
-	BUG(11, "Bug", new Color(153, 235, 27), 5),
-	ROCK(12, "Rock", new Color(169, 135, 70), 4),
-	GHOST(13, "Ghost", new Color(92, 61, 139), 6),
-	DRAGON(14, "Dragon", new Color(106, 90, 205), 14),
-	DARK(15, "Dark", new Color(49, 79, 79), 15),
-	STEEL(16, "Steel", new Color(200, 200, 210), 7),
-	FAIRY(17, "Fairy", new Color(221, 160, 221), -1),
-	NO_TYPE(18, "Unknown", new Color(255, 255, 255, 0), -1); // TODO: TYPE: NULL MUTHAFUCKA
+	NORMAL(0, "Normal", () -> TypeAdvantage.NORMAL, new Color(230, 230, 250), -1),
+	FIRE(1, "Fire", () -> TypeAdvantage.FIRE, new Color(220, 20, 20), 8),
+	WATER(2, "Water", () -> TypeAdvantage.WATER, new Color(35, 120, 220), 9),
+	ELECTRIC(3, "Electric", () -> TypeAdvantage.ELECTRIC, new Color(255, 215, 0), 11),
+	GRASS(4, "Grass", () -> TypeAdvantage.GRASS, new Color(120, 200, 80), 10),
+	ICE(5, "Ice", () -> TypeAdvantage.ICE, new Color(5, 235, 235), 13),
+	FIGHTING(6, "Fighting", () -> TypeAdvantage.FIGHTING, new Color(165, 82, 57), 0),
+	POISON(7, "Poison", () -> TypeAdvantage.POISON, new Color(150, 30, 160), 2),
+	GROUND(8, "Ground", () -> TypeAdvantage.GROUND, new Color(190, 170, 120), 3),
+	FLYING(9, "Flying", () -> TypeAdvantage.FLYING, new Color(135, 206, 250), 1),
+	PSYCHIC(10, "Psychic", () -> TypeAdvantage.PSYCHIC, new Color(218, 112, 214), 12),
+	BUG(11, "Bug", () -> TypeAdvantage.BUG, new Color(153, 235, 27), 5),
+	ROCK(12, "Rock", () -> TypeAdvantage.ROCK, new Color(169, 135, 70), 4),
+	GHOST(13, "Ghost", () -> TypeAdvantage.GHOST, new Color(92, 61, 139), 6),
+	DRAGON(14, "Dragon", () -> TypeAdvantage.DRAGON, new Color(106, 90, 205), 14),
+	DARK(15, "Dark", () -> TypeAdvantage.DARK, new Color(49, 79, 79), 15),
+	STEEL(16, "Steel", () -> TypeAdvantage.STEEL, new Color(200, 200, 210), 7),
+	FAIRY(17, "Fairy", () -> TypeAdvantage.FAIRY, new Color(221, 160, 221), -1),
+	NO_TYPE(18, "Unknown", () -> TypeAdvantage.NO_TYPE, new Color(255, 255, 255, 0), -1); // TODO: TYPE: NULL MUTHAFUCKA
 
 	// TODO: This is ass do that other thingy
 	private static final double typeAdvantage[][] = {
@@ -60,13 +60,15 @@ public enum Type implements Serializable {
 
 	private final int index;
 	private final String name;
+	private final AdvantageGetter advantageGetter;
 	private final Color color;
 	private final int hiddenIndex;
 	private final BufferedImage image;
 
-	Type(int index, String name, Color color, int hiddenIndex) {
+	Type(int index, String name, AdvantageGetter advantageGetter, Color color, int hiddenIndex) {
 		this.index = index;
 		this.name = name;
+		this.advantageGetter = advantageGetter;
 		this.color = color;
 		this.hiddenIndex = hiddenIndex;
 
@@ -80,6 +82,10 @@ public enum Type implements Serializable {
 
 	public String getName() {
 		return this.name;
+	}
+
+	public TypeAdvantage getAdvantage() {
+		return this.advantageGetter.getAdvantage();
 	}
 
 	public Color getColor() {
@@ -167,5 +173,9 @@ public enum Type implements Serializable {
 		}
 
 		return 1;
+	}
+
+	interface AdvantageGetter {
+		TypeAdvantage getAdvantage();
 	}
 }

--- a/src/main/TypeAdvantage.java
+++ b/src/main/TypeAdvantage.java
@@ -1,0 +1,108 @@
+package main;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public enum TypeAdvantage {
+    NORMAL(new Builder()
+            .weak(Type.ROCK, Type.STEEL)
+            .ineffective(Type.GHOST)),
+    FIRE(new Builder()
+            .strong(Type.GRASS, Type.ICE, Type.BUG, Type.STEEL)
+            .weak(Type.FIRE, Type.WATER, Type.ROCK, Type.DRAGON)),
+    WATER(new Builder()
+            .strong(Type.FIRE, Type.GROUND, Type.ROCK)
+            .weak(Type.WATER, Type.GRASS, Type.DRAGON)),
+    ELECTRIC(new Builder()
+            .strong(Type.WATER, Type.FLYING)
+            .weak(Type.ELECTRIC, Type.GRASS, Type.DRAGON)
+            .ineffective(Type.GROUND)),
+    GRASS(new Builder()
+            .strong(Type.WATER, Type.GROUND, Type.ROCK)
+            .weak(Type.FIRE, Type.GRASS, Type.POISON, Type.FLYING, Type.BUG, Type.DRAGON, Type.STEEL)),
+    ICE(new Builder()
+            .strong(Type.GRASS, Type.GROUND, Type.FLYING, Type.DRAGON)
+            .weak(Type.FIRE, Type.WATER, Type.ICE, Type.STEEL)),
+    FIGHTING(new Builder()
+            .strong(Type.NORMAL, Type.ICE, Type.ROCK, Type.DARK, Type.STEEL)
+            .weak(Type.POISON, Type.FLYING, Type.PSYCHIC, Type.BUG, Type.FAIRY)
+            .ineffective(Type.GHOST)),
+    POISON(new Builder()
+            .strong(Type.GRASS, Type.FAIRY)
+            .weak(Type.POISON, Type.GROUND, Type.ROCK, Type.GHOST)
+            .ineffective(Type.STEEL)),
+    GROUND(new Builder()
+            .strong(Type.FIRE, Type.ELECTRIC, Type.POISON, Type.ROCK, Type.STEEL)
+            .weak(Type.GRASS, Type.BUG)
+            .ineffective(Type.FLYING)),
+    FLYING(new Builder()
+            .strong(Type.GRASS, Type.FIGHTING, Type.BUG)
+            .weak(Type.ELECTRIC, Type.ROCK, Type.STEEL)),
+    PSYCHIC(new Builder()
+            .strong(Type.FIGHTING, Type.POISON)
+            .weak(Type.PSYCHIC, Type.STEEL)
+            .ineffective(Type.DARK)),
+    BUG(new Builder()
+            .strong(Type.GRASS, Type.PSYCHIC, Type.DARK)
+            .weak(Type.FIRE, Type.FIGHTING, Type.POISON, Type.FLYING, Type.GHOST, Type.STEEL, Type.FAIRY)),
+    ROCK(new Builder()
+            .strong(Type.FIRE, Type.ICE, Type.FLYING, Type.BUG)
+            .weak(Type.FIGHTING, Type.GROUND, Type.STEEL)),
+    GHOST(new Builder()
+            .strong(Type.PSYCHIC, Type.GHOST)
+            .weak(Type.DARK)
+            .ineffective(Type.NORMAL)),
+    DRAGON(new Builder()
+            .strong(Type.DRAGON)
+            .weak(Type.STEEL)
+            .ineffective(Type.FAIRY)),
+    DARK(new Builder()
+            .strong(Type.PSYCHIC, Type.GHOST)
+            .weak(Type.FIGHTING, Type.DARK, Type.FAIRY)),
+    STEEL(new Builder()
+            .strong(Type.ICE, Type.ROCK, Type.FAIRY)
+            .weak(Type.FIRE, Type.WATER, Type.ELECTRIC, Type.STEEL)),
+    FAIRY(new Builder()
+            .strong(Type.FIGHTING, Type.DRAGON, Type.DARK)
+            .weak(Type.FIRE, Type.POISON, Type.STEEL)),
+    NO_TYPE(new Builder());
+
+    private final Map<Type, Double> advantageMap;
+
+    TypeAdvantage(Builder builder) {
+        this.advantageMap = builder.advantageMap;
+    }
+
+    public double getAdvantage(Type defending) {
+        return advantageMap.get(defending);
+    }
+
+    private static class Builder {
+        private final Map<Type, Double> advantageMap;
+
+        public Builder() {
+            this.advantageMap = new EnumMap<>(Type.class);
+            setAdvantage(1, Type.values());
+        }
+
+        Builder strong(Type... values) {
+            return setAdvantage(2, values);
+        }
+
+        Builder weak(Type... values) {
+            return setAdvantage(.5, values);
+        }
+
+        Builder ineffective(Type... values) {
+            return setAdvantage(0, values);
+        }
+
+        private Builder setAdvantage(double advantage, Type... values) {
+            for (Type type : values) {
+                this.advantageMap.put(type, advantage);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/map/TerrainType.java
+++ b/src/map/TerrainType.java
@@ -5,7 +5,7 @@ import battle.attack.AttackNamesies;
 import battle.effect.generic.EffectNamesies;
 import battle.effect.status.StatusCondition;
 import main.Game;
-import main.Type;
+import type.Type;
 import pokemon.Stat;
 
 import java.awt.image.BufferedImage;

--- a/src/message/MessageUpdate.java
+++ b/src/message/MessageUpdate.java
@@ -7,7 +7,7 @@ import gui.view.ViewMode;
 import gui.view.battle.BattleView;
 import gui.view.battle.VisualState;
 import main.Game;
-import main.Type;
+import type.Type;
 import message.Messages.MessageState;
 import pattern.action.ChoiceActionMatcher.ChoiceMatcher;
 import pokemon.ActivePokemon;

--- a/src/pokemon/ActivePokemon.java
+++ b/src/pokemon/ActivePokemon.java
@@ -35,7 +35,7 @@ import item.hold.EVItem;
 import item.hold.HoldItem;
 import main.Game;
 import main.Global;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.MessageUpdate.Update;
 import message.Messages;

--- a/src/pokemon/ActivePokemon.java
+++ b/src/pokemon/ActivePokemon.java
@@ -1105,20 +1105,17 @@ public class ActivePokemon implements Serializable {
 	
 	// Returns true if the Pokemon is currently levitating for any reason
 	public boolean isLevitating(Battle b, ActivePokemon moldBreaker) {
-
-		// Grounded effect take precedence over levitation effects
-		if (isGrounded(b)) {
-			return false;
-		}
-		
-		// Obvs levitating if you have a levitation effect
-		// Stupid motherfucking Mold Breaker not allowing me to make Levitate a Levitation effect, fuck you Mold Breaker. -- NOT ANYMORE NOW WE HAVE Battle.hasInvoke FUCK YES YOU GO GLENN COCO
-		if (LevitationEffect.containsLevitationEffect(b, this, moldBreaker)) {
-			return true;
-		}
-		
 		// Flyahs gon' Fly
-		return isType(b, Type.FLYING);
+		return isLevitatingWithoutTypeCheck(b, moldBreaker) || isType(b, Type.FLYING);
+	}
+
+	// Returns true if the Pokemon is currently levitating for any reason besides being a flying type pokemon
+	// Grounded effect take precedence over levitation effects
+	// Obvs levitating if you have a levitation effect
+	// Stupid motherfucking Mold Breaker not allowing me to make Levitate a Levitation effect, fuck you Mold Breaker. -- NOT ANYMORE NOW WE HAVE Battle.hasInvoke FUCK YES YOU GO GLENN COCO
+	public boolean isLevitatingWithoutTypeCheck(Battle b, ActivePokemon moldBreaker) {
+		return !isGrounded(b) && LevitationEffect.containsLevitationEffect(b, this, moldBreaker);
+
 	}
 
 	public void giveItem(ItemNamesies itemName) {

--- a/src/pokemon/PokemonInfo.java
+++ b/src/pokemon/PokemonInfo.java
@@ -5,7 +5,7 @@ import item.Item;
 import item.ItemNamesies;
 import item.hold.HoldItem;
 import item.hold.IncenseItem;
-import main.Type;
+import type.Type;
 import pokemon.ability.AbilityNamesies;
 import pokemon.breeding.EggGroup;
 import pokemon.evolution.Evolution;

--- a/src/pokemon/ability/Ability.java
+++ b/src/pokemon/ability/Ability.java
@@ -17,7 +17,6 @@ import battle.effect.attack.ChangeTypeSource;
 import battle.effect.generic.CastSource;
 import battle.effect.generic.EffectInterfaces.AbsorbDamageEffect;
 import battle.effect.generic.EffectInterfaces.AccuracyBypassEffect;
-import battle.effect.generic.EffectInterfaces.AdvantageChanger;
 import battle.effect.generic.EffectInterfaces.AlwaysCritEffect;
 import battle.effect.generic.EffectInterfaces.ApplyDamageEffect;
 import battle.effect.generic.EffectInterfaces.BeforeTurnEffect;
@@ -36,6 +35,7 @@ import battle.effect.generic.EffectInterfaces.HalfWeightEffect;
 import battle.effect.generic.EffectInterfaces.LevitationEffect;
 import battle.effect.generic.EffectInterfaces.MurderEffect;
 import battle.effect.generic.EffectInterfaces.NameChanger;
+import battle.effect.generic.EffectInterfaces.NoAdvantageChanger;
 import battle.effect.generic.EffectInterfaces.OpponentAccuracyBypassEffect;
 import battle.effect.generic.EffectInterfaces.OpponentBeforeTurnEffect;
 import battle.effect.generic.EffectInterfaces.OpponentEndAttackEffect;
@@ -72,7 +72,6 @@ import item.hold.HoldItem;
 import item.hold.SpecialTypeItem.MemoryItem;
 import item.hold.SpecialTypeItem.PlateItem;
 import main.Global;
-import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;
@@ -82,6 +81,7 @@ import pokemon.PokemonNamesies;
 import pokemon.Stat;
 import trainer.Trainer;
 import trainer.WildPokemon;
+import type.Type;
 import type.TypeAdvantage;
 import util.RandomUtils;
 
@@ -1263,19 +1263,15 @@ public abstract class Ability implements Serializable {
 		}
 	}
 
-	static class Scrappy extends Ability implements AdvantageChanger {
+	static class Scrappy extends Ability implements NoAdvantageChanger {
 		private static final long serialVersionUID = 1L;
 
 		Scrappy() {
 			super(AbilityNamesies.SCRAPPY, "Enables moves to hit Ghost-type foes.");
 		}
 
-		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			if (attacking == Type.NORMAL || attacking == Type.FIGHTING) {
-				TypeAdvantage.removeDefendingType(defending, Type.GHOST);
-			}
-			
-			return defending;
+		public boolean negateNoAdvantage(Type attacking, Type defending) {
+			return defending == Type.GHOST && (attacking == Type.NORMAL || attacking == Type.FIGHTING);
 		}
 	}
 

--- a/src/pokemon/ability/Ability.java
+++ b/src/pokemon/ability/Ability.java
@@ -369,7 +369,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? 2 : 1;
+			return TypeAdvantage.isNotVeryEffective(user, victim, b) ? 2 : 1;
 		}
 	}
 
@@ -1319,7 +1319,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+			return TypeAdvantage.isSuperEffective(user, victim, b) ? .75 : 1;
 		}
 	}
 
@@ -1336,7 +1336,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+			return TypeAdvantage.isSuperEffective(user, victim, b) ? .75 : 1;
 		}
 	}
 
@@ -1894,7 +1894,7 @@ public abstract class Ability implements Serializable {
 			}
 			
 			// Super effective moves hit
-			if (TypeAdvantage.getAdvantage(p, opp, b) > 1) {
+			if (TypeAdvantage.isSuperEffective(p, opp, b)) {
 				return true;
 			}
 			
@@ -1971,7 +1971,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? .75 : 1;
+			return TypeAdvantage.isSuperEffective(user, victim, b) ? .75 : 1;
 		}
 	}
 

--- a/src/pokemon/ability/Ability.java
+++ b/src/pokemon/ability/Ability.java
@@ -2028,7 +2028,7 @@ public abstract class Ability implements Serializable {
 			ActivePokemon other = b.getOtherPokemon(enterer.isPlayer());
 			for (Move m : other.getMoves(b)) {
 				Attack attack = m.getAttack();
-				if (TypeAdvantage.getBasicAdvantage(attack.getActualType(), enterer, b) > 1 || attack.isMoveType(MoveType.ONE_HIT_KO)) {
+				if (attack.getActualType().getAdvantage().isSuperEffective(enterer, b) || attack.isMoveType(MoveType.ONE_HIT_KO)) {
 					// TODO: Shouldn't this be for a random move?
 					Messages.add(new MessageUpdate(enterer.getName() + "'s " + this.getName() + " made it shudder!"));
 					break;

--- a/src/pokemon/ability/Ability.java
+++ b/src/pokemon/ability/Ability.java
@@ -369,7 +369,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return Type.getAdvantage(user, victim, b) < 1 ? 2 : 1;
+			return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? 2 : 1;
 		}
 	}
 
@@ -1325,7 +1325,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return Type.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+			return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
 		}
 	}
 
@@ -1342,7 +1342,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return Type.getAdvantage(user, victim, b) > 1 ? .75 : 1;
+			return TypeAdvantage.getAdvantage(user, victim, b) > 1 ? .75 : 1;
 		}
 	}
 
@@ -1900,7 +1900,7 @@ public abstract class Ability implements Serializable {
 			}
 			
 			// Super effective moves hit
-			if (Type.getAdvantage(p, opp, b) > 1) {
+			if (TypeAdvantage.getAdvantage(p, opp, b) > 1) {
 				return true;
 			}
 			
@@ -1977,7 +1977,7 @@ public abstract class Ability implements Serializable {
 		}
 
 		public double getOpponentMultiplier(Battle b, ActivePokemon user, ActivePokemon victim) {
-			return Type.getAdvantage(user, victim, b) < 1 ? .75 : 1;
+			return TypeAdvantage.getAdvantage(user, victim, b) < 1 ? .75 : 1;
 		}
 	}
 
@@ -2028,7 +2028,7 @@ public abstract class Ability implements Serializable {
 			ActivePokemon other = b.getOtherPokemon(enterer.isPlayer());
 			for (Move m : other.getMoves(b)) {
 				Attack attack = m.getAttack();
-				if (Type.getBasicAdvantage(attack.getActualType(), enterer, b) > 1 || attack.isMoveType(MoveType.ONE_HIT_KO)) {
+				if (TypeAdvantage.getBasicAdvantage(attack.getActualType(), enterer, b) > 1 || attack.isMoveType(MoveType.ONE_HIT_KO)) {
 					// TODO: Shouldn't this be for a random move?
 					Messages.add(new MessageUpdate(enterer.getName() + "'s " + this.getName() + " made it shudder!"));
 					break;

--- a/src/pokemon/ability/Ability.java
+++ b/src/pokemon/ability/Ability.java
@@ -1271,10 +1271,8 @@ public abstract class Ability implements Serializable {
 		}
 
 		public Type[] getAdvantageChange(Type attacking, Type[] defending) {
-			for (int i = 0; i < 2; i++) {
-				if ((attacking == Type.NORMAL || attacking == Type.FIGHTING) && defending[i] == Type.GHOST) {
-					defending[i] = Type.NO_TYPE;
-				}
+			if (attacking == Type.NORMAL || attacking == Type.FIGHTING) {
+				TypeAdvantage.removeDefendingType(defending, Type.GHOST);
 			}
 			
 			return defending;

--- a/src/pokemon/ability/Ability.java
+++ b/src/pokemon/ability/Ability.java
@@ -82,6 +82,7 @@ import pokemon.PokemonNamesies;
 import pokemon.Stat;
 import trainer.Trainer;
 import trainer.WildPokemon;
+import type.TypeAdvantage;
 import util.RandomUtils;
 
 import java.io.Serializable;

--- a/src/pokemon/ability/Ability.java
+++ b/src/pokemon/ability/Ability.java
@@ -72,7 +72,7 @@ import item.hold.HoldItem;
 import item.hold.SpecialTypeItem.MemoryItem;
 import item.hold.SpecialTypeItem.PlateItem;
 import main.Global;
-import main.Type;
+import type.Type;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/test/AbilityTest.java
+++ b/src/test/AbilityTest.java
@@ -1,0 +1,40 @@
+package test;
+
+import battle.Battle;
+import battle.attack.AttackNamesies;
+import battle.attack.Move;
+import item.ItemNamesies;
+import org.junit.Assert;
+import org.junit.Test;
+import pokemon.PokemonNamesies;
+import pokemon.ability.AbilityNamesies;
+import type.TypeAdvantage;
+
+public class AbilityTest {
+    private static TestPokemon getPokemon(PokemonNamesies pokemon, AbilityNamesies ability) {
+        return new TestPokemon(pokemon).withAbility(ability);
+    }
+
+    @Test
+    public void testLevitate() {
+        TestPokemon attacking = new TestPokemon(PokemonNamesies.BULBASAUR);
+        TestPokemon defending = getPokemon(PokemonNamesies.KOFFING, AbilityNamesies.LEVITATE);
+
+        Battle battle = TestBattle.create(attacking, defending);
+
+        // Ground moves should not hit a levitating Pokemon
+        attacking.setMove(new Move(AttackNamesies.EARTHQUAKE));
+        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) == 0);
+
+        // Even if holding a Ring Target
+        defending.giveItem(ItemNamesies.RING_TARGET);
+        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) == 0);
+
+        // Unless the user has mold breaker
+        attacking.withAbility(AbilityNamesies.MOLD_BREAKER);
+        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) > 0);
+
+        defending.removeItem();
+        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) > 0);
+    }
+}

--- a/src/test/AbilityTest.java
+++ b/src/test/AbilityTest.java
@@ -24,17 +24,38 @@ public class AbilityTest {
 
         // Ground moves should not hit a levitating Pokemon
         attacking.setMove(new Move(AttackNamesies.EARTHQUAKE));
-        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) == 0);
+        Assert.assertTrue(TypeAdvantage.doesNotEffect(attacking, defending, battle));
 
         // Even if holding a Ring Target
         defending.giveItem(ItemNamesies.RING_TARGET);
-        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) == 0);
+        Assert.assertTrue(TypeAdvantage.doesNotEffect(attacking, defending, battle));
 
         // Unless the user has mold breaker
         attacking.withAbility(AbilityNamesies.MOLD_BREAKER);
-        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) > 0);
+        Assert.assertFalse(TypeAdvantage.doesNotEffect(attacking, defending, battle));
 
         defending.removeItem();
-        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) > 0);
+        Assert.assertFalse(TypeAdvantage.doesNotEffect(attacking, defending, battle));
+    }
+
+    @Test
+    public void wonderGuardTest() {
+        TestPokemon attacking = new TestPokemon(PokemonNamesies.BULBASAUR);
+        TestPokemon defending = getPokemon(PokemonNamesies.SHEDINJA, AbilityNamesies.WONDER_GUARD);
+
+        TestBattle battle = TestBattle.create(attacking, defending);
+
+        // Status move should work
+        Assert.assertTrue(battle.ableToAttack(AttackNamesies.DRAGON_DANCE, attacking, defending));
+        Assert.assertTrue(battle.ableToAttack(AttackNamesies.THUNDER_WAVE, attacking, defending));
+
+        // Super-effective moves and moves without type work
+        Assert.assertTrue(battle.ableToAttack(AttackNamesies.SHADOW_BALL, attacking, defending));
+        Assert.assertTrue(battle.ableToAttack(AttackNamesies.STRUGGLE, attacking, defending));
+
+        // Attacking non-super effective moves should not work
+        Assert.assertFalse(battle.ableToAttack(AttackNamesies.SURF, attacking, defending));
+        Assert.assertFalse(battle.ableToAttack(AttackNamesies.VINE_WHIP, attacking, defending));
+        Assert.assertFalse(battle.ableToAttack(AttackNamesies.TACKLE, attacking, defending));
     }
 }

--- a/src/test/PokemonManipulator.java
+++ b/src/test/PokemonManipulator.java
@@ -1,0 +1,66 @@
+package test;
+
+import battle.Battle;
+import battle.effect.generic.CastSource;
+import battle.effect.generic.EffectNamesies;
+import item.ItemNamesies;
+import pokemon.ActivePokemon;
+import pokemon.ability.AbilityNamesies;
+
+interface PokemonManipulator {
+    void manipulate(Battle battle, ActivePokemon attacking, ActivePokemon defending);
+
+    static void startAttack(Battle battle, ActivePokemon attacking, ActivePokemon defending) {
+        attacking.startAttack(battle, defending);
+    }
+
+    static void giveEffect(EffectNamesies effectNamesies, Battle battle, ActivePokemon attacking, ActivePokemon defending, boolean attackingTarget) {
+        ActivePokemon caster = attackingTarget ? defending : attacking;
+        ActivePokemon victim = attackingTarget ? attacking : defending;
+
+        effectNamesies.getEffect().cast(battle, caster, victim, CastSource.ATTACK, false);
+        startAttack(battle, attacking, defending);
+    }
+
+    static void giveAbility(AbilityNamesies abilityNamesies, Battle battle, ActivePokemon attacking, ActivePokemon defending, boolean attackingTarget) {
+        ActivePokemon victim = attackingTarget ? attacking : defending;
+
+        victim.setAbility(abilityNamesies);
+        startAttack(battle, attacking, defending);
+    }
+
+    static void giveItem(ItemNamesies itemNamesies, Battle battle, ActivePokemon attacking, ActivePokemon defending, boolean attackingTarget) {
+        ActivePokemon victim = attackingTarget ? attacking : defending;
+
+        victim.giveItem(itemNamesies);
+        startAttack(battle, attacking, defending);
+    }
+
+    static PokemonManipulator empty() {
+        return PokemonManipulator::startAttack;
+    }
+
+    static PokemonManipulator giveAttackingEffect(EffectNamesies effectNamesies) {
+        return (battle, attacking, defending) -> giveEffect(effectNamesies, battle, attacking, defending, true);
+    }
+
+    static PokemonManipulator giveDefendingEffect(EffectNamesies effectNamesies) {
+        return (battle, attacking, defending) -> giveEffect(effectNamesies, battle, attacking, defending, false);
+    }
+
+    static PokemonManipulator giveAttackingAbility(AbilityNamesies abilityNamesies) {
+        return (battle, attacking, defending) -> giveAbility(abilityNamesies, battle, attacking, defending, true);
+    }
+
+    static PokemonManipulator giveDefendingAbility(AbilityNamesies abilityNamesies) {
+        return (battle, attacking, defending) -> giveAbility(abilityNamesies, battle, attacking, defending, false);
+    }
+
+    static PokemonManipulator giveAttackingItem(ItemNamesies itemNamesies) {
+        return (battle, attacking, defending) -> giveItem(itemNamesies, battle, attacking, defending, true);
+    }
+
+    static PokemonManipulator giveDefendingItem(ItemNamesies itemNamesies) {
+        return (battle, attacking, defending) -> giveItem(itemNamesies, battle, attacking, defending, false);
+    }
+}

--- a/src/test/TestBattle.java
+++ b/src/test/TestBattle.java
@@ -13,8 +13,4 @@ class TestBattle extends Battle {
         new TestCharacter(mahBoiiiiiii);
         return new TestBattle(nahMahBoi);
     }
-
-    interface PokemonManipulator {
-        void manipulate(Battle battle, ActivePokemon attacking, ActivePokemon defending);
-    }
 }

--- a/src/test/TestBattle.java
+++ b/src/test/TestBattle.java
@@ -13,4 +13,8 @@ class TestBattle extends Battle {
         new TestCharacter(mahBoiiiiiii);
         return new TestBattle(nahMahBoi);
     }
+
+    interface PokemonManipulator {
+        void manipulate(Battle battle, ActivePokemon attacking, ActivePokemon defending);
+    }
 }

--- a/src/test/TestBattle.java
+++ b/src/test/TestBattle.java
@@ -1,12 +1,22 @@
 package test;
 
 import battle.Battle;
+import battle.attack.AttackNamesies;
 import pokemon.ActivePokemon;
 import trainer.WildPokemon;
 
 class TestBattle extends Battle {
     private TestBattle(ActivePokemon nahMahBoi) {
         super(new WildPokemon(nahMahBoi));
+    }
+
+    public double getDamageModifier(ActivePokemon attacking, ActivePokemon defending) {
+        return super.getDamageModifier(attacking, defending);
+    }
+
+    public boolean ableToAttack(AttackNamesies attack, TestPokemon attacking, ActivePokemon defending) {
+        attacking.setupMove(attack, this, defending);
+        return super.ableToAttack(attacking, defending);
     }
 
     static TestBattle create(ActivePokemon mahBoiiiiiii, ActivePokemon nahMahBoi) {

--- a/src/test/TestPokemon.java
+++ b/src/test/TestPokemon.java
@@ -1,5 +1,8 @@
 package test;
 
+import battle.Battle;
+import battle.attack.AttackNamesies;
+import battle.attack.Move;
 import pokemon.ActivePokemon;
 import pokemon.Gender;
 import pokemon.PokemonNamesies;
@@ -18,5 +21,10 @@ class TestPokemon extends ActivePokemon {
     TestPokemon withAbility(AbilityNamesies ability) {
         super.setAbility(ability);
         return this;
+    }
+
+    void setupMove(AttackNamesies attackNamesies, Battle battle, ActivePokemon defending) {
+        this.setMove(new Move(attackNamesies));
+        this.startAttack(battle, defending);
     }
 }

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -10,6 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import pokemon.ActivePokemon;
 import pokemon.PokemonNamesies;
+import pokemon.ability.AbilityNamesies;
 import test.TestBattle.PokemonManipulator;
 import type.Type;
 import type.TypeAdvantage;
@@ -51,18 +52,24 @@ public class TypeTest {
     }
 
     @Test
-    public void ringTargetTest() {
+    public void changeEffectivenessTest() {
+        // Foresight and Miracle Eye
+        foresightTest(PokemonNamesies.GASTLY, AttackNamesies.TACKLE, EffectNamesies.FORESIGHT);
+        foresightTest(PokemonNamesies.UMBREON, AttackNamesies.PSYCHIC, EffectNamesies.MIRACLE_EYE);
+
+        // Ring Target
         changeEffectivenessTest(
                 PokemonNamesies.PIDGEY,
                 AttackNamesies.EARTHQUAKE,
                 (battle, attacking, defending) -> defending.giveItem(ItemNamesies.RING_TARGET)
         );
-    }
 
-    @Test
-    public void foresightTest() {
-        foresightTest(PokemonNamesies.GASTLY, AttackNamesies.TACKLE, EffectNamesies.FORESIGHT);
-        foresightTest(PokemonNamesies.UMBREON, AttackNamesies.PSYCHIC, EffectNamesies.MIRACLE_EYE);
+        // Scrappy
+        changeEffectivenessTest(
+                PokemonNamesies.GASTLY,
+                AttackNamesies.TACKLE,
+                (battle, attacking, defending) -> attacking.setAbility(AbilityNamesies.SCRAPPY)
+        );
     }
 
     private void foresightTest(PokemonNamesies defendingPokemon, AttackNamesies attack, EffectNamesies effect) {
@@ -73,7 +80,6 @@ public class TypeTest {
         );
     }
 
-    // TODO: Scrappy
     private void changeEffectivenessTest(PokemonNamesies defendingPokemon, AttackNamesies attack, PokemonManipulator manipulator) {
         ActivePokemon attacking = new TestPokemon(PokemonNamesies.BULBASAUR);
         ActivePokemon defending = new TestPokemon(defendingPokemon);

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -63,32 +63,19 @@ public class TypeTest {
     @Test
     public void changeEffectivenessTest() {
         // Foresight
-        changeEffectivenessTest(
-                PokemonNamesies.GASTLY,
-                AttackNamesies.TACKLE,
-                PokemonManipulator.giveDefendingEffect(EffectNamesies.FORESIGHT)
-        );
+        changeEffectivenessTest(PokemonNamesies.GASTLY, AttackNamesies.TACKLE, PokemonManipulator.giveDefendingEffect(EffectNamesies.FORESIGHT));
+        changeEffectivenessTest(PokemonNamesies.GASTLY, AttackNamesies.KARATE_CHOP, PokemonManipulator.giveDefendingEffect(EffectNamesies.FORESIGHT));
 
         // Miracle Eye
-        changeEffectivenessTest(
-                PokemonNamesies.UMBREON,
-                AttackNamesies.PSYCHIC,
-                PokemonManipulator.giveDefendingEffect(EffectNamesies.MIRACLE_EYE)
-        );
+        changeEffectivenessTest(PokemonNamesies.UMBREON, AttackNamesies.PSYCHIC, PokemonManipulator.giveDefendingEffect(EffectNamesies.MIRACLE_EYE));
 
         // Ring Target
-        changeEffectivenessTest(
-                PokemonNamesies.PIDGEY,
-                AttackNamesies.EARTHQUAKE,
-                PokemonManipulator.giveDefendingItem(ItemNamesies.RING_TARGET)
-        );
+        changeEffectivenessTest(PokemonNamesies.PIDGEY, AttackNamesies.EARTHQUAKE, PokemonManipulator.giveDefendingItem(ItemNamesies.RING_TARGET));
+        changeEffectivenessTest(PokemonNamesies.SANDSHREW, AttackNamesies.THUNDER_PUNCH, PokemonManipulator.giveDefendingItem(ItemNamesies.RING_TARGET));
 
         // Scrappy
-        changeEffectivenessTest(
-                PokemonNamesies.GASTLY,
-                AttackNamesies.TACKLE,
-                PokemonManipulator.giveAttackingAbility(AbilityNamesies.SCRAPPY)
-        );
+        changeEffectivenessTest(PokemonNamesies.GASTLY, AttackNamesies.TACKLE, PokemonManipulator.giveAttackingAbility(AbilityNamesies.SCRAPPY));
+        changeEffectivenessTest(PokemonNamesies.GASTLY, AttackNamesies.KARATE_CHOP, PokemonManipulator.giveAttackingAbility(AbilityNamesies.SCRAPPY));
     }
 
     private void changeEffectivenessTest(PokemonNamesies defendingPokemon, AttackNamesies attack, PokemonManipulator manipulator) {
@@ -194,9 +181,12 @@ public class TypeTest {
         advantageChecker(1, freezeDry, PokemonNamesies.LAPRAS);
 
         // Super effective against a non-water type Pokemon that has been soaked
-        PokemonManipulator soak = (battle, attacking, defending) ->
-                attacking.callNewMove(battle, defending, new Move(AttackNamesies.SOAK));
-        advantageChecker(2, freezeDry, soak, PokemonNamesies.PIDGEY);
+        advantageChecker(
+                2,
+                freezeDry,
+                (battle, attacking, defending) -> attacking.callNewMove(battle, defending, new Move(AttackNamesies.SOAK)),
+                PokemonNamesies.PIDGEY
+        );
     }
 
     @Test

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -1,0 +1,43 @@
+package test;
+
+import main.Type;
+import main.TypeAdvantage;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TypeTest {
+    private static final double typeAdvantage[][] = {
+            {1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, .5,  0,  1,  1, .5,  1, 1}, // Normal
+            {1, .5, .5,  1,  2,  2,  1,  1,  1,  1,  1,  2, .5,  1, .5,  1,  2,  1, 1}, // Fire
+            {1,  2, .5,  1, .5,  1,  1,  1,  2,  1,  1,  1,  2,  1, .5,  1,  1,  1, 1}, // Water
+            {1,  1,  2, .5, .5,  1,  1,  1,  0,  2,  1,  1,  1,  1, .5,  1,  1,  1, 1}, // Electric
+            {1, .5,  2,  1, .5,  1,  1, .5,  2, .5,  1, .5,  2,  1, .5,  1, .5,  1, 1}, // Grass
+            {1, .5, .5,  1,  2, .5,  1,  1,  2,  2,  1,  1,  1,  1,  2,  1, .5,  1, 1}, // Ice
+            {2,  1,  1,  1,  1,  2,  1, .5,  1, .5, .5, .5,  2,  0,  1,  2,  2, .5, 1}, // Fighting
+            {1,  1,  1,  1,  2,  1,  1, .5, .5,  1,  1,  1, .5, .5,  1,  1,  0,  2, 1}, // Poison
+            {1,  2,  1,  2, .5,  1,  1,  2,  1,  0,  1, .5,  2,  1,  1,  1,  2,  1, 1}, // Ground
+            {1,  1,  1, .5,  2,  1,  2,  1,  1,  1,  1,  2, .5,  1,  1,  1, .5,  1, 1}, // Flying
+            {1,  1,  1,  1,  1,  1,  2,  2,  1,  1, .5,  1,  1,  1,  1,  0, .5,  1, 1}, // Psychic
+            {1, .5,  1,  1,  2,  1, .5, .5,  1, .5,  2,  1,  1, .5,  1,  2, .5, .5, 1}, // Bug
+            {1,  2,  1,  1,  1,  2, .5,  1, .5,  2,  1,  2,  1,  1,  1,  1, .5,  1, 1}, // Rock
+            {0,  1,  1,  1,  1,  1,  1,  1,  1,  1,  2,  1,  1,  2,  1, .5,  1,  1, 1}, // Ghost
+            {1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  2,  1, .5,  0, 1}, // Dragon
+            {1,  1,  1,  1,  1,  1, .5,  1,  1,  1,  2,  1,  1,  2,  1, .5,  1, .5, 1}, // Dark
+            {1, .5, .5, .5,  1,  2,  1,  1,  1,  1,  1,  1,  2,  1,  1,  1, .5,  2, 1}, // Steel
+            {1, .5,  1,  1,  1,  1,  2, .5,  1,  1,  1,  1,  1,  1,  2,  2, .5,  1, 1}, // Fairy
+            {1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1}}; // No Type
+
+    @Test
+    public void typeAdvantageTest() {
+        for (Type attacking : Type.values()) {
+            TypeAdvantage advantage = attacking.getAdvantage();
+            for (int i = 0; i < typeAdvantage[attacking.getIndex()].length; i++) {
+                Type defending = Type.values()[i];
+                double chartAdv = typeAdvantage[attacking.getIndex()][i];
+                double classAdv = advantage.getAdvantage(defending);
+
+                Assert.assertTrue(String.format("%s %s %f %f", attacking, defending, chartAdv, classAdv), chartAdv  == classAdv);
+            }
+        }
+    }
+}

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -151,6 +151,18 @@ public class TypeTest {
         damageModifierTest(PokemonNamesies.SQUIRTLE, AttackNamesies.VINE_WHIP, 1.2, PokemonManipulator.giveAttackingItem(ItemNamesies.EXPERT_BELT));
         damageModifierTest(PokemonNamesies.SQUIRTLE, AttackNamesies.DARK_PULSE, 1, PokemonManipulator.giveAttackingItem(ItemNamesies.EXPERT_BELT));
         damageModifierTest(PokemonNamesies.SQUIRTLE, AttackNamesies.SURF, 1, PokemonManipulator.giveAttackingItem(ItemNamesies.EXPERT_BELT));
+
+        // Tanga berry reduces super-effective bug moves
+        damageModifierTest(PokemonNamesies.KADABRA, AttackNamesies.X_SCISSOR, .5, PokemonManipulator.giveDefendingItem(ItemNamesies.TANGA_BERRY));
+        damageModifierTest(PokemonNamesies.KADABRA, AttackNamesies.CRUNCH, 1, PokemonManipulator.giveDefendingItem(ItemNamesies.TANGA_BERRY));
+        damageModifierTest(PokemonNamesies.KADABRA, AttackNamesies.SURF, 1, PokemonManipulator.giveDefendingItem(ItemNamesies.TANGA_BERRY));
+        damageModifierTest(PokemonNamesies.KADABRA, AttackNamesies.PSYBEAM, 1, PokemonManipulator.giveDefendingItem(ItemNamesies.TANGA_BERRY));
+
+        // Yache berry reduces super-effective ice moves
+        damageModifierTest(PokemonNamesies.DRAGONITE, AttackNamesies.ICE_BEAM, .5, PokemonManipulator.giveDefendingItem(ItemNamesies.YACHE_BERRY));
+        damageModifierTest(PokemonNamesies.DRAGONITE, AttackNamesies.OUTRAGE, 1, PokemonManipulator.giveDefendingItem(ItemNamesies.YACHE_BERRY));
+        damageModifierTest(PokemonNamesies.DRAGONITE, AttackNamesies.TACKLE, 1, PokemonManipulator.giveDefendingItem(ItemNamesies.YACHE_BERRY));
+        damageModifierTest(PokemonNamesies.DRAGONITE, AttackNamesies.SURF, 1, PokemonManipulator.giveDefendingItem(ItemNamesies.YACHE_BERRY));
     }
 
     private void damageModifierTest(PokemonNamesies defendingName, AttackNamesies attackName, double expectedChange, PokemonManipulator manipulator) {

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -1,7 +1,7 @@
 package test;
 
-import main.Type;
-import main.TypeAdvantage;
+import type.Type;
+import type.TypeAdvantage;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -1,5 +1,11 @@
 package test;
 
+import battle.Battle;
+import battle.attack.AttackNamesies;
+import battle.attack.Move;
+import item.ItemNamesies;
+import pokemon.ActivePokemon;
+import pokemon.PokemonNamesies;
 import type.Type;
 import type.TypeAdvantage;
 import org.junit.Assert;
@@ -39,5 +45,19 @@ public class TypeTest {
                 Assert.assertTrue(String.format("%s %s %f %f", attacking, defending, chartAdv, classAdv), chartAdv  == classAdv);
             }
         }
+    }
+
+    @Test
+    public void ringTargetTest() {
+        ActivePokemon attacking = TestUtil.getPokemon(PokemonNamesies.SANDSHREW);
+        ActivePokemon defending = TestUtil.getPokemon(PokemonNamesies.PIDGEY);
+
+        Battle battle = TestBattle.create(attacking, defending);
+
+        attacking.setMove(new Move(AttackNamesies.EARTHQUAKE));
+        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) == 0);
+
+        defending.giveItem(ItemNamesies.RING_TARGET);
+        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) > 0);
     }
 }

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -49,8 +49,8 @@ public class TypeTest {
 
     @Test
     public void ringTargetTest() {
-        ActivePokemon attacking = TestUtil.getPokemon(PokemonNamesies.SANDSHREW);
-        ActivePokemon defending = TestUtil.getPokemon(PokemonNamesies.PIDGEY);
+        ActivePokemon attacking = new TestPokemon(PokemonNamesies.SANDSHREW);
+        ActivePokemon defending = new TestPokemon(PokemonNamesies.PIDGEY);
 
         Battle battle = TestBattle.create(attacking, defending);
 

--- a/src/test/TypeTest.java
+++ b/src/test/TypeTest.java
@@ -101,18 +101,18 @@ public class TypeTest {
 
     @Test
     public void freezeDryTest() {
-        ActivePokemon attacking = new TestPokemon(PokemonNamesies.BULBASAUR);
-        ActivePokemon defending = new TestPokemon(PokemonNamesies.SQUIRTLE);
-
-        Battle battle = TestBattle.create(attacking, defending);
+        AttackNamesies freezeDry = AttackNamesies.FREEZE_DRY;
 
         // Freeze-Dry is super effective against water types
-        attacking.setMove(new Move(AttackNamesies.FREEZE_DRY));
-        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) > 1);
+        advantageChecker(2, freezeDry, PokemonNamesies.SQUIRTLE);
 
         // Should have neutral effectiveness against a Water/Ice type, instead of .25
-        defending = new TestPokemon(PokemonNamesies.LAPRAS);
-        Assert.assertTrue(TypeAdvantage.getAdvantage(attacking, defending, battle) == 1);
+        advantageChecker(1, freezeDry, PokemonNamesies.LAPRAS);
+
+        // Super effective against a non-water type Pokemon that has been soaked
+        PokemonManipulator soak = (battle, attacking, defending) ->
+                attacking.callNewMove(battle, defending, new Move(AttackNamesies.SOAK));
+        advantageChecker(2, freezeDry, soak, PokemonNamesies.PIDGEY);
     }
 
     @Test
@@ -211,34 +211,35 @@ public class TypeTest {
                 PokemonNamesies.MIMIKYU
         };
 
-        AttackNamesies attack = AttackNamesies.FLYING_PRESS;
-        advantageChecker(4, attack, superDuperEffective);
-        advantageChecker(2, attack, superEffective);
-        advantageChecker(1, attack, neutralEffective);
-        advantageChecker(.5, attack, notVeryEffective);
-        advantageChecker(.25, attack, superNotVeryEffective);
-        advantageChecker(0, attack, noEffect);
+        // Flying Press is simultaneously a Fighting/Flying attack
+        AttackNamesies flyingPress = AttackNamesies.FLYING_PRESS;
+        advantageChecker(4, flyingPress, superDuperEffective);
+        advantageChecker(2, flyingPress, superEffective);
+        advantageChecker(1, flyingPress, neutralEffective);
+        advantageChecker(.5, flyingPress, notVeryEffective);
+        advantageChecker(.25, flyingPress, superNotVeryEffective);
+        advantageChecker(0, flyingPress, noEffect);
 
         // Electrify should make the attack Electic/Flying
         PokemonManipulator electrify = PokemonManipulator.giveAttackingEffect(EffectNamesies.ELECTRIFIED);
-        advantageChecker(4, attack, electrify, PokemonNamesies.HAWLUCHA, PokemonNamesies.BUTTERFREE);
-        advantageChecker(2, attack, electrify, PokemonNamesies.CATERPIE, PokemonNamesies.LARVESTA);
-        advantageChecker(1, attack, electrify, PokemonNamesies.ALAKAZAM, PokemonNamesies.AERODACTYL);
-        advantageChecker(.5, attack, electrify, PokemonNamesies.ZAPDOS, PokemonNamesies.MAWILE, PokemonNamesies.KLINK);
-        advantageChecker(.25, attack, electrify, PokemonNamesies.PIKACHU, PokemonNamesies.SHIELDON);
-        advantageChecker(.125, attack, electrify, PokemonNamesies.ZEKROM, PokemonNamesies.MAGNEZONE);
-        advantageChecker(0, attack, electrify, PokemonNamesies.SANDSHREW, PokemonNamesies.GLIGAR);
+        advantageChecker(4, flyingPress, electrify, PokemonNamesies.HAWLUCHA, PokemonNamesies.BUTTERFREE);
+        advantageChecker(2, flyingPress, electrify, PokemonNamesies.CATERPIE, PokemonNamesies.LARVESTA);
+        advantageChecker(1, flyingPress, electrify, PokemonNamesies.ALAKAZAM, PokemonNamesies.AERODACTYL);
+        advantageChecker(.5, flyingPress, electrify, PokemonNamesies.ZAPDOS, PokemonNamesies.MAWILE, PokemonNamesies.KLINK);
+        advantageChecker(.25, flyingPress, electrify, PokemonNamesies.PIKACHU, PokemonNamesies.SHIELDON);
+        advantageChecker(.125, flyingPress, electrify, PokemonNamesies.ZEKROM, PokemonNamesies.MAGNEZONE);
+        advantageChecker(0, flyingPress, electrify, PokemonNamesies.SANDSHREW, PokemonNamesies.GLIGAR);
 
         // Normalize should make the attack Normal/Flying
         PokemonManipulator normalize = PokemonManipulator.giveAttackingAbility(AbilityNamesies.NORMALIZE);
-        advantageChecker(4, attack, normalize, PokemonNamesies.BRELOOM, PokemonNamesies.PARASECT);
-        advantageChecker(2, attack, normalize, PokemonNamesies.MACHAMP, PokemonNamesies.BULBASAUR);
-        advantageChecker(1, attack, normalize, PokemonNamesies.PIDGEY, PokemonNamesies.JOLTIK);
-        advantageChecker(.5, attack, normalize, PokemonNamesies.PIKACHU, PokemonNamesies.LILEEP, PokemonNamesies.LANTURN);
-        advantageChecker(.25, attack, normalize, PokemonNamesies.KLINK, PokemonNamesies.BOLDORE);
-        advantageChecker(.125, attack, normalize, PokemonNamesies.MAGNEMITE);
-        advantageChecker(.0625, attack, normalize, PokemonNamesies.SHIELDON);
-        advantageChecker(0, attack, normalize, PokemonNamesies.GASTLY, PokemonNamesies.BANETTE);
+        advantageChecker(4, flyingPress, normalize, PokemonNamesies.BRELOOM, PokemonNamesies.PARASECT);
+        advantageChecker(2, flyingPress, normalize, PokemonNamesies.MACHAMP, PokemonNamesies.BULBASAUR);
+        advantageChecker(1, flyingPress, normalize, PokemonNamesies.PIDGEY, PokemonNamesies.JOLTIK);
+        advantageChecker(.5, flyingPress, normalize, PokemonNamesies.PIKACHU, PokemonNamesies.LILEEP, PokemonNamesies.LANTURN);
+        advantageChecker(.25, flyingPress, normalize, PokemonNamesies.KLINK, PokemonNamesies.BOLDORE);
+        advantageChecker(.125, flyingPress, normalize, PokemonNamesies.MAGNEMITE);
+        advantageChecker(.0625, flyingPress, normalize, PokemonNamesies.SHIELDON);
+        advantageChecker(0, flyingPress, normalize, PokemonNamesies.GASTLY, PokemonNamesies.BANETTE);
     }
 
     private void advantageChecker(double expectedAdvantage, AttackNamesies attack, PokemonNamesies... defendingPokemon) {

--- a/src/type/Type.java
+++ b/src/type/Type.java
@@ -73,7 +73,7 @@ public enum Type implements Serializable {
 	}
 	
 	public static Color[] getColors(Type[] t) {
-		return new Color[] {t[0].getColor(), t[t[1] == Type.NO_TYPE ? 0 : 1].getColor()};
+		return new Color[] { t[0].getColor(), t[t[1] == Type.NO_TYPE ? 0 : 1].getColor() };
 	}
 	
 	public static Color[] getColors(ActivePokemon p) {

--- a/src/type/Type.java
+++ b/src/type/Type.java
@@ -100,7 +100,7 @@ public enum Type implements Serializable {
 		return false;
 	}
 
-	interface AdvantageGetter {
+	private interface AdvantageGetter {
 		TypeAdvantage getAdvantage();
 	}
 }

--- a/src/type/Type.java
+++ b/src/type/Type.java
@@ -1,9 +1,10 @@
-package main;
+package type;
 
 import battle.Battle;
 import battle.attack.MoveType;
 import battle.effect.generic.EffectInterfaces.AdvantageChanger;
 import battle.effect.generic.EffectInterfaces.AdvantageMultiplierMove;
+import main.Global;
 import message.MessageUpdate;
 import message.Messages;
 import pokemon.ActivePokemon;

--- a/src/type/TypeAdvantage.java
+++ b/src/type/TypeAdvantage.java
@@ -1,4 +1,4 @@
-package main;
+package type;
 
 import java.util.EnumMap;
 import java.util.Map;

--- a/src/type/TypeAdvantage.java
+++ b/src/type/TypeAdvantage.java
@@ -85,15 +85,6 @@ public enum TypeAdvantage {
         return advantageMap.get(defending);
     }
 
-    public double getAdvantage(Battle b, ActivePokemon attacking, ActivePokemon defending, Type defendingType) {
-        if (doesNotEffect(defendingType)
-                && NoAdvantageChanger.checkNoAdvantageChanger(b, attacking, defending, this.type, defendingType)) {
-            return 1;
-        }
-
-        return getAdvantage(defendingType);
-    }
-
     public double getAdvantage(Type[] defending) {
         return this.getAdvantage(defending[0], defending[1]);
     }
@@ -107,16 +98,31 @@ public enum TypeAdvantage {
     }
 
     public boolean isSuperEffective(ActivePokemon defending, Battle b) {
-        return this.getAdvantage(defending, b) > 1;
+        return isSuperEffective(this.getAdvantage(defending, b));
     }
 
-    // Also includes moves that do not effect at all
+    public boolean isSuperEffective(Type defending) {
+        return isSuperEffective(this.getAdvantage(defending));
+    }
+
     public boolean isNotVeryEffective(Type defending) {
-        return this.getAdvantage(defending) < 1;
+        return isNotVeryEffective(this.getAdvantage(defending));
     }
 
     public boolean doesNotEffect(Type defending) {
-        return this.getAdvantage(defending) == 0;
+        return doesNotEffect(this.getAdvantage(defending));
+    }
+
+    public static boolean isSuperEffective(ActivePokemon attacking, ActivePokemon defending, Battle b) {
+        return isSuperEffective(getAdvantage(attacking, defending, b));
+    }
+
+    public static boolean isNotVeryEffective(ActivePokemon attacking, ActivePokemon defending, Battle b) {
+        return isNotVeryEffective(getAdvantage(attacking, defending, b));
+    }
+
+    public static boolean doesNotEffect(ActivePokemon attacking, ActivePokemon defending, Battle b) {
+        return doesNotEffect(getAdvantage(attacking, defending, b));
     }
 
     public static double getAdvantage(ActivePokemon attacking, ActivePokemon defending, Battle b) {
@@ -144,7 +150,6 @@ public enum TypeAdvantage {
             advantage *= typeAdvantage.getAdvantage(defendingType);
         }
 
-        // TODO: Change this too
         // Get the advantage and apply any multiplier that may come from the attack
         advantage = AdvantageMultiplierMove.updateModifier(advantage, attacking, attackingType, defendingTypes);
 
@@ -159,6 +164,31 @@ public enum TypeAdvantage {
         }
 
         return 1;
+    }
+
+    public static boolean isSuperEffective(double advantage) {
+        return advantage > 1;
+    }
+
+    // Also includes moves that do not effect at all
+    public static boolean isNotVeryEffective(double advantage) {
+        return advantage < 1;
+    }
+
+    public static boolean doesNotEffect(double advantage) {
+        return advantage == 0;
+    }
+
+    public static String getSuperEffectiveMessage() {
+        return "It's super effective!";
+    }
+
+    public static String getNotVeryEffectiveMessage() {
+        return "It's not very effective...";
+    }
+
+    public static String getDoesNotEffectMessage(ActivePokemon opp) {
+        return "It doesn't affect " + opp.getName() + "!";
     }
 
     private static class Builder {

--- a/src/type/TypeAdvantage.java
+++ b/src/type/TypeAdvantage.java
@@ -106,7 +106,7 @@ public enum TypeAdvantage {
     }
 
     public boolean doesNotEffect(Type defending) {
-        return this.getAdvantage(defending) == 1;
+        return this.getAdvantage(defending) == 0;
     }
 
     public static double getAdvantage(ActivePokemon attacking, ActivePokemon defending, Battle b) {

--- a/src/type/TypeAdvantage.java
+++ b/src/type/TypeAdvantage.java
@@ -124,11 +124,7 @@ public enum TypeAdvantage {
             }
 
             // If the Pokemon is not levitating due to some effect and is flying type, ground moves should hit
-            for (int i = 0; i < 2; i++) {
-                if (defendingType[i] == Type.FLYING) {
-                    defendingType[i] = Type.NO_TYPE;
-                }
-            }
+            removeDefendingType(defendingType, Type.FLYING);
         }
 
         // Get the advantage and apply any multiplier that may come from the attack
@@ -136,6 +132,14 @@ public enum TypeAdvantage {
         adv = AdvantageMultiplierMove.updateModifier(adv, attacking, moveType, defendingType);
 
         return adv;
+    }
+
+    public static void removeDefendingType(Type[] defendingType, Type toRemove) {
+        for (int i = 0; i < defendingType.length; i++) {
+            if (defendingType[i] == toRemove) {
+                defendingType[i] = Type.NO_TYPE;
+            }
+        }
     }
 
     public static double getSTAB(Battle b, ActivePokemon p) {

--- a/src/util/DrawUtils.java
+++ b/src/util/DrawUtils.java
@@ -1,7 +1,7 @@
 package util;
 
 import main.Global;
-import main.Type;
+import type.Type;
 import map.Direction;
 
 import java.awt.Color;

--- a/src/util/StringUtils.java
+++ b/src/util/StringUtils.java
@@ -92,6 +92,15 @@ public class StringUtils {
         return builder.toString();
     }
 
+    public static String spaceSeparated(Object... values) {
+        StringBuilder builder = new StringBuilder();
+        for (Object value : values) {
+            builder.append(value).append(" ");
+        }
+
+        return builder.toString();
+    }
+
     // TODO: Look at this again and rewrite it
     public static String properCase(String string) {
         if (isNullOrEmpty(string)) {


### PR DESCRIPTION
Lots of changes related to type advantage calculation and effects and utility methods and tests and whatnot.

- Type advantage is no longer stored in that giant type chart 2d array
  - new TypeAdvantage enum which holds an enum map from type to advantage
  - much easier to read
- No longer updates the defending Pokemon's type when calculating type advantage
  - This used to occur for things like Foresight, but now only applies the zero multiplier when the effect is not present
  - Changed AdvantageChangerEffect -> NoAdvantageChangerEffect as it is only triggered when the attack does not affect the opponent
  - This new interface just returns a boolean now of whether or not the advantage should be counted instead of type array manipulation
- Added utility methods for things like the following:
  - Before: Type.getAdvantage(user, victim, b) < 1
  - After: TypeAdvantage.isNotVeryEffective(user, victim, b)
- New type package
- Got kind of carried away with adding testing cases
- Guess what Solid Rock didn't work before woops
- Maybe other things that I don't feel like writing and then again maybe not